### PR TITLE
Fix for JENKINS-24999

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
-.idea/
+target/*
+work/*
+.settings/*
+.classpath
+.project
+.idea
 *.iml
+/target
 .DS_Store
-target
-work
+**/.DS_Store

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPushCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPushCause.java
@@ -12,6 +12,10 @@ public class BitBucketPushCause extends SCMTrigger.SCMTriggerCause {
 
     private String pushedBy;
 
+    public BitBucketPushCause(String pusher) {
+        this("", pusher);
+    }
+    
     public BitBucketPushCause(String pollingLog, String pusher) {
         super(pollingLog);
         pushedBy = pusher;

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
@@ -20,10 +20,9 @@ public class BitBucketTrigger extends Trigger<AbstractProject> {
     public BitBucketTrigger() {
     }
 
-    public void onPost(String user, URIish repository, String sha1, String branch) {
-        for (GitStatus.Listener listener : Jenkins.getInstance().getExtensionList(GitStatus.Listener.class)) {
-            listener.onNotifyCommit(repository, sha1, new String[] { branch });
-        }
+    public void onPost(AbstractProject<?,?> job, String user) {
+    	BitBucketPushCause cause = new BitBucketPushCause(user);
+    	job.scheduleBuild(cause);	
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -121,7 +121,7 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
                     BitBucketTrigger trigger = job.getTrigger(BitBucketTrigger.class);
                     if (trigger!=null) {
                         if (match(job.getScm(), remote)) {
-                            trigger.onPost(user, remote, sha1, branch);
+                        	trigger.onPost(job, user);
                         } else LOGGER.info("job SCM doesn't match remote repo");
                     } else LOGGER.info("job hasn't BitBucketTrigger set");
                 }


### PR DESCRIPTION
This change fix JENKINS-24999.

To reproduce this issue you need to:
- Create two jobs using the same BitBucket repo
- Only in one of them check "Build when a change is pushed to BitBucket"

Result: Both jobs are triggered even if you only checked the "Build when a change is pushed to BitBucket" option in one of them.
