### PR TITLE
[FIXED JENKINS-26805] Job not triggered after git merge on a branch

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -9,7 +9,6 @@ import hudson.plugins.git.GitStatus;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -105,11 +104,6 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
         String user = payload.getString("user");
         String url = payload.getString("canon_url") + repo.getString("absolute_url");
         LOGGER.info("Received commit hook notification for "+repo);
-
-        JSONArray commits = payload.getJSONArray("commits");
-        int last = commits.size() - 1;
-        String sha1 = commits.getJSONObject(last).getString("raw_node");
-        String branch = commits.getJSONObject(last).getString("branch");
 
         String scm = repo.getString("scm");
         if ("git".equals(scm)) {


### PR DESCRIPTION
When you merge a branch into a another one and then do a `git push` you get the stacktrace below:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
at java.util.ArrayList.elementData(ArrayList.java:400)
at java.util.ArrayList.get(ArrayList.java:413)
at net.sf.json.JSONArray.get(JSONArray.java:1881)
at net.sf.json.JSONArray.getJSONObject(JSONArray.java:1970)
at com.cloudbees.jenkins.plugins.BitbucketHookReceiver.processPayload(BitbucketHookReceiver.java:111)
at com.cloudbees.jenkins.plugins.BitbucketHookReceiver.doIndex(BitbucketHookReceiver.java:60)
```
The lines of the code below in BitBucketHookReceiver are not used and they are producing the above stacktrace.
```
JSONArray commits = payload.getJSONArray("commits");
int last = commits.size() - 1;
String sha1 = commits.getJSONObject(last).getString("raw_node");
String branch = commits.getJSONObject(last).getString("branch");
```
Just need to delete them.