### PR TITLE
JENKINS-28877

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -61,41 +61,163 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
     
 /*
 {
-    "canon_url": "https://bitbucket.org",
-    "commits": [
-        {
-            "author": "marcus",
-            "branch": "master",
-            "files": [
-                {
-                    "file": "somefile.py",
-                    "type": "modified"
+    "push": {
+        "changes": [{
+            "old": {
+                "type": "branch",
+                "target": {
+                    "date": "2015-06-22T21:47:01+00:00",
+                    "type": "commit",
+                    "author": {
+                        "raw": "author <author@somedomain.com>"
+                    },
+                    "message": "some message\n",
+                    "links": {
+                        "html": {
+                            "href": "https://bitbucket.org/owner/somerepo/commits/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                        },
+                        "self": {
+                            "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                        }
+                    },
+                    "hash": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    "parents": [{
+                        "type": "commit",
+                        "hash": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                        "links": {
+                            "html": {
+                                "href": "https://bitbucket.org/owner/somerepo/commits/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                            },
+                            "self": {
+                                "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                            }
+                        }
+                    }]
+                },
+                "name": "master",
+                "links": {
+                    "html": {
+                        "href": "https://bitbucket.org/owner/somerepo/branch/master"
+                    },
+                    "commits": {
+                        "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commits/master"
+                    },
+                    "self": {
+                        "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/refs/branches/master"
+                    }
                 }
-            ],
-            "message": "Added some more things to somefile.py\n",
-            "node": "620ade18607a",
-            "parents": [
-                "702c70160afc"
-            ],
-            "raw_author": "Marcus Bertrand <marcus@somedomain.com>",
-            "raw_node": "620ade18607ac42d872b568bb92acaa9a28620e9",
-            "revision": null,
-            "size": -1,
-            "timestamp": "2012-05-30 05:58:56",
-            "utctimestamp": "2012-05-30 03:58:56+00:00"
-        }
-    ],
-    "repository": {
-        "absolute_url": "/marcus/project-x/",
-        "fork": false,
-        "is_private": true,
-        "name": "Project X",
-        "owner": "marcus",
-        "scm": "git",
-        "slug": "project-x",
-        "website": "https://atlassian.com/"
+            },
+            "closed": false,
+            "links": {
+                "html": {
+                    "href": "https://bitbucket.org/owner/somerepo/branches/compare/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                },
+                "commits": {
+                    "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commits?include=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxexclude=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                },
+                "diff": {
+                    "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/diff/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                }
+            },
+            "forced": false,
+            "new": {
+                "type": "branch",
+                "target": {
+                    "date": "2015-06-22T22:20:08+00:00",
+                    "type": "commit",
+                    "author": {
+                        "raw": "author <author@somedomain.com>"
+                    },
+                    "message": "some message\n",
+                    "links": {
+                        "html": {
+                            "href": "https://bitbucket.org/owner/somerepo/commits/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                        },
+                        "self": {
+                            "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                        }
+                    },
+                    "hash": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    "parents": [{
+                        "type": "commit",
+                        "hash": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                        "links": {
+                            "html": {
+                                "href": "https://bitbucket.org/owner/somerepo/commits/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                            },
+                            "self": {
+                                "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commit/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                            }
+                        }
+                    }]
+                },
+                "name": "master",
+                "links": {
+                    "html": {
+                        "href": "https://bitbucket.org/owner/somerepo/branch/master"
+                    },
+                    "commits": {
+                        "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/commits/master"
+                    },
+                    "self": {
+                        "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo/refs/branches/master"
+                    }
+                }
+            },
+            "created": false
+        }]
     },
-    "user": "marcus"
+    "actor": {
+        "type": "team",
+        "uuid": "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}",
+        "username": "owner",
+        "display_name": "Owner",
+        "links": {
+            "avatar": {
+                "href": "https://bitbucket.org/account/owner/avatar/32/"
+            },
+            "html": {
+                "href": "https://bitbucket.org/owner"
+            },
+            "self": {
+                "href": "https://bitbucket.org/api/2.0/teams/owner"
+            }
+        }
+    },
+    "repository": {
+        "full_name": "owner/somerepo",
+        "owner": {
+            "type": "team",
+            "uuid": "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}",
+            "username": "owner",
+            "display_name": "Owner",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket.org/account/owner/avatar/32/"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/owner"
+                },
+                "self": {
+                    "href": "https://bitbucket.org/api/2.0/teams/owner"
+                }
+            }
+        },
+        "type": "repository",
+        "name": "somerepo",
+        "uuid": "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}",
+        "links": {
+            "avatar": {
+                "href": "https://bitbucket.org/owner/somerepo/avatar/16/"
+            },
+            "html": {
+                "href": "https://bitbucket.org/owner/somerepo"
+            },
+            "self": {
+                "href": "https://bitbucket.org/api/2.0/repositories/owner/somerepo"
+            }
+        }
+    }
 }
 */
     private void processPayload(JSONObject payload) {


### PR DESCRIPTION
The BitBucket event payload changed so made some modifications accordingly.  Instead of supplying a string for the "user", an "actor" object is included, which you can grab the username from.  Instead of "canon_url" and "absolute_url", the "repository" object has a "links" object that you can grab the repo url from.  "scm" is no longer included.  It's possible to get "scm" by making an api request, but if the repo is private, it would require authentication as well.  There are additional checks in processPayload() so I felt safe removing the check for now