### PR TITLE
added support for Bitbucket's new webhooks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 @Extension
 public class BitbucketHookReceiver implements UnprotectedRootAction {
 
-
     public String getIconFileName() {
         return null;
     }
@@ -56,7 +55,27 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
 
         LOGGER.fine("Received commit hook notification : " + body);
         JSONObject payload = JSONObject.fromObject(body);
-        processPayload(payload);
+
+        if ("Bitbucket-Webhooks/2.0".equals(req.getHeader("user-agent"))) {
+            if ("repo:push".equals(req.getHeader("x-event-key"))) {
+                LOGGER.info("Processing new Webhooks payload");
+                processWebhookPayload(payload);
+            }
+        } else {
+            LOGGER.info("Processing old POST service payload");
+            processPostServicePayload(payload);
+        }
+    }
+
+    private void processWebhookPayload(JSONObject payload) {
+        JSONObject repo = payload.getJSONObject("repository");
+        LOGGER.info("Received commit hook notification for "+repo);
+
+        String user = payload.getJSONObject("actor").getString("username");
+        String url = repo.getJSONObject("links").getJSONObject("html").getString("href");
+        String scm = repo.has("scm") ? repo.getString("scm") : "git";
+
+        triggerMatchingJobs(user, url, scm);
     }
 
 /*
@@ -98,14 +117,18 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
     "user": "marcus"
 }
 */
-    private void processPayload(JSONObject payload) {
-
+    private void processPostServicePayload(JSONObject payload) {
         JSONObject repo = payload.getJSONObject("repository");
-        String user = payload.getString("user");
-        String url = payload.getString("canon_url") + repo.getString("absolute_url");
         LOGGER.info("Received commit hook notification for "+repo);
 
+        String user = payload.getString("user");
+        String url = payload.getString("canon_url") + repo.getString("absolute_url");
         String scm = repo.getString("scm");
+
+        triggerMatchingJobs(user, url, scm);
+    }
+
+    private void triggerMatchingJobs(String user, String url, String scm) {
         if ("git".equals(scm)) {
             SecurityContext old = Jenkins.getInstance().getACL().impersonate(ACL.SYSTEM);
             try {
@@ -115,7 +138,7 @@ public class BitbucketHookReceiver implements UnprotectedRootAction {
                     BitBucketTrigger trigger = job.getTrigger(BitBucketTrigger.class);
                     if (trigger!=null) {
                         if (match(job.getScm(), remote)) {
-                        	trigger.onPost(user);
+                            trigger.onPost(user);
                         } else LOGGER.info("job SCM doesn't match remote repo");
                     } else LOGGER.info("job hasn't BitBucketTrigger set");
                 }


### PR DESCRIPTION
Bitbucket has [new webhooks](http://blog.bitbucket.org/2015/06/24/the-new-bitbucket-webhooks/) with a more extensive payload than the old POST service this plugin is currently implemented against. Requests from the new webhooks include the user-agent "Bitbucket-Webhooks/2.0", so this PR introduces logic to detect that and conditionally parse either the new payload or the old payload based on that.

This PR includes a very simple version of this change, with no tests. I will create a separate PR with the same change + some unit tests. In order to write the tests, I had to do some refactoring; so the changes in the other PR will be more extensive, hence the two PRs so you can decide between a simpler change w/o tests or a more substantial change w/ tests.