### PR TITLE
[FIXED JENKINS-30985] Trigger only one build per same scm

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -68,8 +68,8 @@ public class BitbucketJobProbe {
         }
     }
 
-    private boolean hasBeenTriggered(List<SCM> smcTriggered, SCM scmTrigger) {
-        for (SCM scm : smcTriggered) {
+    private boolean hasBeenTriggered(List<SCM> scmTriggered, SCM scmTrigger) {
+        for (SCM scm : scmTriggered) {
             if (scm.equals(scmTrigger)) {
                 return true;
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -7,6 +7,8 @@ import hudson.scm.SCM;
 import hudson.security.ACL;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,10 +45,11 @@ public class BitbucketJobProbe {
                     if (bTrigger != null) {
                         LOGGER.log(Level.FINE, "Considering to poke {0}", job.getFullDisplayName());
                         SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
-
+                        List<SCM> scmTriggered = new ArrayList<SCM>();
                         for (SCM scmTrigger : item.getSCMs()) {
-                            if (match(scmTrigger, remote)) {
+                            if (match(scmTrigger, remote) && !hasBeenTriggered(scmTriggered, scmTrigger)) {
                                 LOGGER.log(Level.INFO, "Triggering BitBucket job {0}", job.getName());
+                                scmTriggered.add(scmTrigger);
                                 bTrigger.onPost(user);
                             } else LOGGER.log(Level.FINE, "{0} SCM doesn't match remote repo {1}", new Object[]{job.getName(), remote});
                         }
@@ -63,6 +66,15 @@ public class BitbucketJobProbe {
             // TODO hg
             throw new UnsupportedOperationException("Unsupported SCM type " + scm);
         }
+    }
+
+    private boolean hasBeenTriggered(List<SCM> smcTriggered, SCM scmTrigger) {
+        for (SCM scm : smcTriggered) {
+            if (scm.equals(scmTrigger)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean match(SCM scm, URIish url) {


### PR DESCRIPTION
Jobs with the same git repository defined several times in the scm should be triggered only once.

This includes the case where in a Workflow job you define a Workflow Script from SCM with a git repo and then in the Script Path you are checking out the same git repo.

https://issues.jenkins-ci.org/browse/JENKINS-30985

@reviewbybees @amuniz @jglick 