### PR TITLE
[FIXED JENKINS-31185] Added hg support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>plugin</artifactId>
         <version>1.580.1</version> <!-- minimun required version to work with Workflow 1.4 SCMTriggerItem was added in 1.568. 1.580.x is the next LTS after that-->
     </parent>
- 
+
     <artifactId>bitbucket</artifactId>
     <version>1.1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -62,6 +62,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <version>2.3.5</version>
+        </dependency>
+        <dependency> <!-- minimun required version to work with Workflow 1.4 GitSCM step-->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mercurial</artifactId>
+            <version>1.54</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -1,26 +1,29 @@
 package com.cloudbees.jenkins.plugins;
 
-import com.google.common.base.Objects;
 import hudson.model.Job;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.mercurial.MercurialSCM;
 import hudson.scm.SCM;
 import hudson.security.ACL;
+
 import java.net.URISyntaxException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import hudson.triggers.Trigger;
 import jenkins.model.Jenkins;
+
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
+import com.google.common.base.Objects;
 
 public class BitbucketJobProbe {
 
@@ -54,7 +57,7 @@ public class BitbucketJobProbe {
                             } else LOGGER.log(Level.FINE, "{0} SCM doesn't match remote repo {1}", new Object[]{job.getName(), remote});
                         }
                     } else
-                    LOGGER.log(Level.FINE, "{0} hasn't BitBucketTrigger set", job.getName());
+                        LOGGER.log(Level.FINE, "{0} hasn't BitBucketTrigger set", job.getName());
                 }
             } catch (URISyntaxException e) {
                 LOGGER.log(Level.WARNING, "Invalid repository URL {0}", url);
@@ -80,18 +83,20 @@ public class BitbucketJobProbe {
         if (scm instanceof GitSCM) {
             for (RemoteConfig remoteConfig : ((GitSCM) scm).getRepositories()) {
                 for (URIish urIish : remoteConfig.getURIs()) {
-                    if (GitStatus.looselyMatches(urIish, url))
+                    if (GitStatus.looselyMatches(urIish, url)) {
                         return true;
+                    }
                 }
             }
         } else if (scm instanceof MercurialSCM) {
             try {
                 URI hgUri = new URI(((MercurialSCM) scm).getSource());
                 String remote = url.toString();
-                if (almostMatches(hgUri, remote))
+                if (almostMatches(hgUri, remote)) {
                     return true;
+                }
             } catch (URISyntaxException ex) {
-                LOGGER.log(Level.SEVERE, "Could not parse jobSource uri " + ex);
+                LOGGER.log(Level.SEVERE, "Could not parse jobSource uri: {0} ", ex);
             }
         }
         return false;
@@ -105,7 +110,7 @@ public class BitbucketJobProbe {
             && Objects.equal(notifyUri.getPath(), repositoryUri.getPath())
             && Objects.equal(notifyUri.getQuery(), repositoryUri.getQuery());
         } catch (URISyntaxException ex) {
-            LOGGER.log(Level.SEVERE, "Could not parse repository uri " + repository, ex);
+            LOGGER.log(Level.SEVERE, "Could not parse repository uri: {0}, {1}", repository, ex);
         }
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -110,7 +110,7 @@ public class BitbucketJobProbe {
             && Objects.equal(notifyUri.getPath(), repositoryUri.getPath())
             && Objects.equal(notifyUri.getQuery(), repositoryUri.getQuery());
         } catch (URISyntaxException ex) {
-            LOGGER.log(Level.SEVERE, "Could not parse repository uri: {0}, {1}", repository, ex);
+            LOGGER.log(Level.SEVERE, "Could not parse repository uri: {0}, {1}", new Object[]{repository, ex});
         }
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -92,7 +92,7 @@ public class BitbucketJobProbe {
             try {
                 URI hgUri = new URI(((MercurialSCM) scm).getSource());
                 String remote = url.toString();
-                if (almostMatches(hgUri, remote)) {
+                if (looselyMatches(hgUri, remote)) {
                     return true;
                 }
             } catch (URISyntaxException ex) {
@@ -102,7 +102,7 @@ public class BitbucketJobProbe {
         return false;
     }
 
-    private boolean almostMatches(URI notifyUri, String repository) {
+    private boolean looselyMatches(URI notifyUri, String repository) {
         boolean result = false;
         try {
             URI repositoryUri = new URI(repository);

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
@@ -1,6 +1,9 @@
 package com.cloudbees.jenkins.plugins;
+
 import java.util.logging.Logger;
+
 import javax.servlet.http.HttpServletRequest;
+
 import net.sf.json.JSONObject;
 
 public class BitbucketPayloadProcessor {
@@ -18,11 +21,11 @@ public class BitbucketPayloadProcessor {
     public void processPayload(JSONObject payload, HttpServletRequest request) {
         if ("Bitbucket-Webhooks/2.0".equals(request.getHeader("user-agent"))) {
             if ("repo:push".equals(request.getHeader("x-event-key"))) {
-                LOGGER.info("Processing new Webhooks payload");
+                LOGGER.log(Level.INFO, "Processing new Webhooks payload");
                 processWebhookPayload(payload);
             }
         } else {
-            LOGGER.info("Processing old POST service payload");
+            LOGGER.log(Level.INFO, "Processing old POST service payload");
             processPostServicePayload(payload);
         }
     }
@@ -30,7 +33,7 @@ public class BitbucketPayloadProcessor {
     private void processWebhookPayload(JSONObject payload) {
         if (payload.has("repository")) {
             JSONObject repo = payload.getJSONObject("repository");
-            LOGGER.info("Received commit hook notification for "+repo);
+            LOGGER.log(Level.INFO, "Received commit hook notification for {0}", repo);
 
             String user = payload.getJSONObject("actor").getString("username");
             String url = repo.getJSONObject("links").getJSONObject("html").getString("href");
@@ -38,7 +41,7 @@ public class BitbucketPayloadProcessor {
 
             probe.triggerMatchingJobs(user, url, scm);
         } else if (payload.has("scm")) {
-            LOGGER.info("Received commit hook notification for hg " + payload);
+            LOGGER.log(Level.INFO, "Received commit hook notification for hg: {0}", payload);
             String user = payload.getJSONObject("owner").getString("username");
             String url = payload.getJSONObject("links").getJSONObject("html").getString("href");
             String scm = payload.has("scm") ? payload.getString("scm") : "hg";
@@ -48,9 +51,48 @@ public class BitbucketPayloadProcessor {
 
     }
 
+/*
+{
+    "canon_url": "https://bitbucket.org",
+    "commits": [
+        {
+            "author": "marcus",
+            "branch": "master",
+            "files": [
+                {
+                    "file": "somefile.py",
+                    "type": "modified"
+                }
+            ],
+            "message": "Added some more things to somefile.py\n",
+            "node": "620ade18607a",
+            "parents": [
+                "702c70160afc"
+            ],
+            "raw_author": "Marcus Bertrand <marcus@somedomain.com>",
+            "raw_node": "620ade18607ac42d872b568bb92acaa9a28620e9",
+            "revision": null,
+            "size": -1,
+            "timestamp": "2012-05-30 05:58:56",
+            "utctimestamp": "2012-05-30 03:58:56+00:00"
+        }
+    ],
+    "repository": {
+        "absolute_url": "/marcus/project-x/",
+        "fork": false,
+        "is_private": true,
+        "name": "Project X",
+        "owner": "marcus",
+        "scm": "git",
+        "slug": "project-x",
+        "website": "https://atlassian.com/"
+    },
+    "user": "marcus"
+}
+*/
     private void processPostServicePayload(JSONObject payload) {
         JSONObject repo = payload.getJSONObject("repository");
-        LOGGER.info("Received commit hook notification for "+repo);
+        LOGGER.log(Level.INFO, "Received commit hook notification for {0}", repo);
 
         String user = payload.getString("user");
         String url = payload.getString("canon_url") + repo.getString("absolute_url");

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
@@ -52,9 +52,11 @@ public class BitbucketPayloadProcessorTest {
                     .element("href", url)));
 
         payloadProcessor.processPayload(payload, request);
+
         verify(probe).triggerMatchingJobs(user, url, "git");
 
         payloadProcessor.processPayload(hgLoad, request);
+
         verify(probe).triggerMatchingJobs(user, url, "hg");
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
@@ -43,9 +43,19 @@ public class BitbucketPayloadProcessorTest {
                     .element("html", new JSONObject()
                         .element("href", url))));
 
+        JSONObject hgLoad = new JSONObject()
+            .element("scm", "hg")
+            .element("owner", new JSONObject()
+                .element("username", user))
+            .element("links", new JSONObject()
+                .element("html", new JSONObject()
+                    .element("href", url)));
+
         payloadProcessor.processPayload(payload, request);
-        
         verify(probe).triggerMatchingJobs(user, url, "git");
+
+        payloadProcessor.processPayload(hgLoad, request);
+        verify(probe).triggerMatchingJobs(user, url, "hg");
     }
 
     @Test


### PR DESCRIPTION
First pass attempt to add hg support.  
Tested working on privately hosted Jenkins v. 1.635.  
Only supports web hook payload, not post service payload, though that wouldn't be hard to add.

Resolves [Jenkins-31185](https://issues.jenkins-ci.org/browse/JENKINS-31185).