### PR TITLE
Job Dsl Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ See details on [wiki](https://wiki.jenkins-ci.org/display/JENKINS/BitBucket+Plug
 
 # Job DSL
 The plugin supports the following dsl extension to enable bitbucket pushes to trigger a build:
-```freeStyleJob('test-job') {
+
+```
+freeStyleJob('test-job') {
   triggers{
     bitbucketPush()
   }
-}```
+}
+```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ bitbucket-plugin
 [![Build Status](https://jenkins.ci.cloudbees.com/job/plugins/job/bitbucket-plugin/badge/icon)](https://jenkins.ci.cloudbees.com/job/plugins/job/bitbucket-plugin/)
 
 See details on [wiki](https://wiki.jenkins-ci.org/display/JENKINS/BitBucket+Plugin)
+
+# Job DSL
+The plugin supports the following dsl extension to enable bitbucket pushes to trigger a build:
+```freeStyleJob('test-job') {
+  triggers{
+    bitbucketPush()
+  }
+}```

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <connection>scm:git:git://github.com/jenkinsci/bitbucket-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/bitbucket-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/bitbucket-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
@@ -69,7 +69,12 @@
             <version>2.0.22-beta</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>job-dsl</artifactId>
+            <version>1.40</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>
-

--- a/src/main/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtension.java
@@ -1,0 +1,17 @@
+package com.cloudbees.jenkins.plugins.extensions.dsl;
+
+import com.cloudbees.jenkins.plugins.BitBucketTrigger;
+import hudson.Extension;
+import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+@Extension(optional = true)
+public class BitbucketHookJobDslExtension extends ContextExtensionPoint {
+    @DslExtensionMethod(context = TriggerContext.class)
+    public Object bitbucketPush(Runnable closure) {
+        return new BitBucketTrigger();
+    }
+}
+
+


### PR DESCRIPTION
This will enable anyone using the [Job DSL plugin](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin) to specify bitbucket build triggers easily using the DSL