### PR TITLE
Adding support for destination branch filtering and more actions

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketEvent.java
@@ -43,7 +43,7 @@ public class BitbucketEvent {
         String CREATED = "created";
         String UPDATED = "updated";
         String APPROVED = "approved";
-        String MERGED = "merged";
+        String MERGED = "fulfilled";
     }
 
     private String name;

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketEvent.java
@@ -41,7 +41,9 @@ public class BitbucketEvent {
 
     public interface PULL_REQUEST_ACTIONS {
         String CREATED = "created";
+        String UPDATED = "updated";
         String APPROVED = "approved";
+        String MERGED = "merged";
     }
 
     private String name;
@@ -79,6 +81,10 @@ public class BitbucketEvent {
             if(PULL_REQUEST_ACTIONS.APPROVED.equals(action)) {
                 return true;
             } else if(PULL_REQUEST_ACTIONS.CREATED.equals(action)) {
+                return true;
+            } else if(PULL_REQUEST_ACTIONS.UPDATED.equals(action)) {
+                return true;
+            } else if(PULL_REQUEST_ACTIONS.MERGED.equals(action)) {
                 return true;
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestCreatedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestCreatedCause.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.cause.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
@@ -7,7 +31,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Created by Douglas Miller on 2016/06/13.
+ * The {@link PullRequestCreatedCause} which represents a type of {@link BitbucketTriggerCause}
+ * @since September 27, 2016
+ * @version 2.0
  */
 public class PullRequestCreatedCause extends BitbucketTriggerCause {
     public PullRequestCreatedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestCreatedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestCreatedCause.java
@@ -1,0 +1,22 @@
+package com.cloudbees.jenkins.plugins.cause.pullrequest;
+
+import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+public class PullRequestCreatedCause extends BitbucketTriggerCause {
+    public PullRequestCreatedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {
+        super(pollingLog, bitbucketPayload);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Started by Bitbucket pull request creation";
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestMergedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestMergedCause.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.cause.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
@@ -7,7 +31,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Created by Douglas Miller on 2016/06/13.
+ * The {@link PullRequestMergedCause} which represents a type of {@link BitbucketTriggerCause}
+ * @since September 27, 2016
+ * @version 2.0
  */
 public class PullRequestMergedCause extends BitbucketTriggerCause {
     public PullRequestMergedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {
@@ -16,7 +42,7 @@ public class PullRequestMergedCause extends BitbucketTriggerCause {
 
     @Override
     public String getShortDescription() {
-        return "Started by Bitbucket pull request update";
+        return "Started by Bitbucket pull request merge";
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestMergedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestMergedCause.java
@@ -1,0 +1,22 @@
+package com.cloudbees.jenkins.plugins.cause.pullrequest;
+
+import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+public class PullRequestMergedCause extends BitbucketTriggerCause {
+    public PullRequestMergedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {
+        super(pollingLog, bitbucketPayload);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Started by Bitbucket pull request update";
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestUpdatedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestUpdatedCause.java
@@ -1,0 +1,22 @@
+package com.cloudbees.jenkins.plugins.cause.pullrequest;
+
+import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+public class PullRequestUpdatedCause extends BitbucketTriggerCause {
+    public PullRequestUpdatedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {
+        super(pollingLog, bitbucketPayload);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Started by Bitbucket pull request update";
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestUpdatedCause.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/cause/pullrequest/PullRequestUpdatedCause.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.cause.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
@@ -7,7 +31,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Created by Douglas Miller on 2016/06/13.
+ * The {@link PullRequestUpdatedCause} which represents a type of {@link BitbucketTriggerCause}
+ * @since September 27, 2016
+ * @version 2.0
  */
 public class PullRequestUpdatedCause extends BitbucketTriggerCause {
     public PullRequestUpdatedCause(File pollingLog, BitbucketPayload bitbucketPayload) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtension.java
@@ -28,6 +28,8 @@ import com.cloudbees.jenkins.plugins.BitBucketTrigger;
 import com.cloudbees.jenkins.plugins.filter.BitbucketTriggerFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestApprovedActionFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestCreatedActionFilter;
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestUpdatedActionFilter;
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestMergedActionFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestTriggerFilter;
 import com.cloudbees.jenkins.plugins.filter.repository.RepositoryPushActionFilter;
 import com.cloudbees.jenkins.plugins.filter.repository.RepositoryTriggerFilter;
@@ -67,7 +69,9 @@ public class BitbucketHookJobDslExtension extends ContextExtensionPoint {
     public Object bitbucketPullRequestApprovedAction(boolean onlyIfReviewersApproved) {
         List<BitbucketTriggerFilter> triggers;
         PullRequestApprovedActionFilter pullRequestApprovedActionFilter = new PullRequestApprovedActionFilter(onlyIfReviewersApproved);
-        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestApprovedActionFilter);
+        // dmiller TODO: Determine how to properly deal with the pullRequestTargetBranch
+        String pullRequestTargetBranch = "";
+        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestApprovedActionFilter, pullRequestTargetBranch);
         triggers = new ArrayList<BitbucketTriggerFilter>();
         triggers.add(pullRequestTriggerFilter);
         return new BitBucketTrigger(triggers);
@@ -77,7 +81,33 @@ public class BitbucketHookJobDslExtension extends ContextExtensionPoint {
     public Object bitbucketPullRequestCreatedAction() {
         List<BitbucketTriggerFilter> triggers;
         PullRequestCreatedActionFilter pullRequestCreatedActionFilter = new PullRequestCreatedActionFilter();
-        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestCreatedActionFilter);
+        // dmiller TODO: Determine how to properly deal with the pullRequestTargetBranch
+        String pullRequestTargetBranch = "";
+        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestCreatedActionFilter, pullRequestTargetBranch);
+        triggers = new ArrayList<BitbucketTriggerFilter>();
+        triggers.add(pullRequestTriggerFilter);
+        return new BitBucketTrigger(triggers);
+    }
+
+    @DslExtensionMethod(context = TriggerContext.class)
+    public Object bitbucketPullRequestUpdatedAction() {
+        List<BitbucketTriggerFilter> triggers;
+        PullRequestUpdatedActionFilter pullRequestUpdatedActionFilter = new PullRequestUpdatedActionFilter();
+        // dmiller TODO: Determine how to properly deal with the pullRequestTargetBranch
+        String pullRequestTargetBranch = "";
+        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestUpdatedActionFilter, pullRequestTargetBranch);
+        triggers = new ArrayList<BitbucketTriggerFilter>();
+        triggers.add(pullRequestTriggerFilter);
+        return new BitBucketTrigger(triggers);
+    }
+
+    @DslExtensionMethod(context = TriggerContext.class)
+    public Object bitbucketPullRequestMergedAction() {
+        List<BitbucketTriggerFilter> triggers;
+        PullRequestMergedActionFilter pullRequestMergedActionFilter = new PullRequestMergedActionFilter();
+        // dmiller TODO: Determine how to properly deal with the pullRequestTargetBranch
+        String pullRequestTargetBranch = "";
+        PullRequestTriggerFilter pullRequestTriggerFilter = new PullRequestTriggerFilter(pullRequestMergedActionFilter, pullRequestTargetBranch);
         triggers = new ArrayList<BitbucketTriggerFilter>();
         triggers.add(pullRequestTriggerFilter);
         return new BitBucketTrigger(triggers);

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestApprovedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestApprovedActionFilter.java
@@ -71,7 +71,6 @@ public class PullRequestApprovedActionFilter extends PullRequestActionFilter {
         public String getDisplayName() { return "Approved"; }
     }
 
-
     public boolean getTriggerOnlyIfAllReviewersApproved() {
         return triggerOnlyIfAllReviewersApproved;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestCreatedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestCreatedActionFilter.java
@@ -25,6 +25,7 @@
 package com.cloudbees.jenkins.plugins.filter.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.cause.pullrequest.PullRequestCreatedCause;
 import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
 import hudson.Extension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -45,12 +46,12 @@ public class PullRequestCreatedActionFilter extends PullRequestActionFilter {
 
     @Override
     public boolean shouldTriggerBuild(BitbucketPayload bitbucketPayload) {
-        return false;
+        return true;
     }
 
     @Override
     public BitbucketTriggerCause getCause(File pollingLog, BitbucketPayload pullRequestPayload) throws IOException {
-        return null;
+        return new PullRequestCreatedCause(pollingLog, pullRequestPayload);
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter.java
@@ -1,0 +1,35 @@
+package com.cloudbees.jenkins.plugins.filter.pullrequest;
+
+import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.cause.pullrequest.PullRequestMergedCause;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+import hudson.Extension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+public class PullRequestMergedActionFilter extends PullRequestActionFilter {
+    @DataBoundConstructor
+    public PullRequestMergedActionFilter() {
+    }
+
+    @Override
+    public boolean shouldTriggerBuild(BitbucketPayload bitbucketPayload) {
+      return true;
+    }
+
+    @Override
+    public BitbucketTriggerCause getCause(File pollingLog, BitbucketPayload pullRequestPayload) throws IOException {
+        return new PullRequestMergedCause(pollingLog, pullRequestPayload);
+    }
+
+    @Extension
+    public static class ActionFilterDescriptorImpl extends PullRequestActionDescriptor {
+        public String getDisplayName() { return "Merged"; }
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.filter.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
@@ -10,7 +34,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Created by Douglas Miller on 2016/06/13.
+ * The {@link PullRequestMergedActionFilter} for the {@link PullRequestMergedAction}
+ * @since September 27, 2016
+ * @version 2.0
  */
 public class PullRequestMergedActionFilter extends PullRequestActionFilter {
     @DataBoundConstructor

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter.java
@@ -128,6 +128,10 @@ public class PullRequestTriggerFilter extends BitbucketTriggerFilter {
                 }
             }
             else {
+                if (previousWildcard) {
+                    builder.append("[^/]*");
+                    previousWildcard = false;
+                }
                 builder.append(Pattern.quote(token));
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerMatcher.java
@@ -40,6 +40,18 @@ public class PullRequestTriggerMatcher implements BitbucketEventTriggerMatcher {
                 triggerFilter.getActionFilter() instanceof PullRequestApprovedActionFilter) {
             return true;
         }
+        else if(BitbucketEvent.PULL_REQUEST_ACTIONS.CREATED.equals(bitbucketEvent.getAction()) &&
+                triggerFilter.getActionFilter() instanceof PullRequestCreatedActionFilter) {
+            return true;
+        }
+        else if(BitbucketEvent.PULL_REQUEST_ACTIONS.UPDATED.equals(bitbucketEvent.getAction()) &&
+                triggerFilter.getActionFilter() instanceof PullRequestUpdatedActionFilter) {
+            return true;
+        }
+        else if(BitbucketEvent.PULL_REQUEST_ACTIONS.MERGED.equals(bitbucketEvent.getAction()) &&
+                triggerFilter.getActionFilter() instanceof PullRequestUpdatedActionFilter) {
+            return true;
+        }
         return false;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.filter.pullrequest;
 
 import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
@@ -10,7 +34,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Created by Douglas Miller on 2016/06/13.
+ * The {@link PullRequestUpdatedActionFilter} for the {@link PullRequestUpdatedAction}
+ * @since September 27, 2016
+ * @version 2.0
  */
 public class PullRequestUpdatedActionFilter extends PullRequestActionFilter {
     @DataBoundConstructor

--- a/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter.java
@@ -1,0 +1,35 @@
+package com.cloudbees.jenkins.plugins.filter.pullrequest;
+
+import com.cloudbees.jenkins.plugins.cause.BitbucketTriggerCause;
+import com.cloudbees.jenkins.plugins.cause.pullrequest.PullRequestUpdatedCause;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+import hudson.Extension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+public class PullRequestUpdatedActionFilter extends PullRequestActionFilter {
+    @DataBoundConstructor
+    public PullRequestUpdatedActionFilter() {
+    }
+
+    @Override
+    public boolean shouldTriggerBuild(BitbucketPayload bitbucketPayload) {
+      return true;
+    }
+
+    @Override
+    public BitbucketTriggerCause getCause(File pollingLog, BitbucketPayload pullRequestPayload) throws IOException {
+        return new PullRequestUpdatedCause(pollingLog, pullRequestPayload);
+    }
+
+    @Extension
+    public static class ActionFilterDescriptorImpl extends PullRequestActionDescriptor {
+        public String getDisplayName() { return "Updated"; }
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/payload/PullRequestPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/payload/PullRequestPayload.java
@@ -46,9 +46,13 @@ public class PullRequestPayload extends BitbucketPayload {
 
         JSONObject pullRequest = payload.getJSONObject("pullrequest");
         JSONObject source = pullRequest.getJSONObject("source");
+        JSONObject destination = pullRequest.getJSONObject("destination");
 
         String branch = source.getJSONObject("branch").getString("name");
         envVars.put("BITBUCKET_BRANCH", branch);
+
+        String targetBranch = destination.getJSONObject("branch").getString("name");
+        envVars.put("BITBUCKET_TARGET_BRANCH", targetBranch);
 
         String pullRequestUrl = pullRequest.getJSONObject("links").getJSONObject("html").getString("href");
         envVars.put("PULL_REQUEST_LINK", pullRequestUrl);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestMergedActionFilter/config.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter/config-detail.jelly
@@ -2,4 +2,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <f:dropdownDescriptorSelector field="actionFilter" title="Select an Action" descriptors="${descriptor.actionDescriptors}">
     </f:dropdownDescriptorSelector>
+    <f:entry title="Destination branch (Wildcards are supported)"
+             field="pullRequestTargetBranch">
+        <f:textbox value="${instance.pullRequestTargetBranch}"
+                   default="**" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter/help-pullRequestTargetBranch.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestTriggerFilter/help-pullRequestTargetBranch.html
@@ -1,0 +1,18 @@
+<div>
+  <p>Destination branch to trigger the job for. If left blank, the '**' wildcard will be used to match all branches.</p>
+
+  <p>Supported options:
+    <ul>
+      <li>
+        <b>Comma separated list</b><br />
+        Multiple branches can be specified with a comma separated list.<br />
+        E.g. <code>develop, master</code>
+      </li>
+      <li>
+        <b>Wildcards</b><br />
+        The <kbd>'*'</kbd> wildcard matches all characters except for '/'. The <kbd><b>'**'</b></kbd> wildcard matches all characters.<br />
+        E.g. <code>release/*, mast*</code>
+      </li>
+    </ul>
+  </p>
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/filter/pullrequest/PullRequestUpdatedActionFilter/config.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketEventTest.java
@@ -97,7 +97,7 @@ public class BitbucketEventTest {
     @Test
     public void testPullRequestEventMergedAction() {
         String event = "pullrequest";
-        String action = "merged";
+        String action = "fulfilled";
 
         BitbucketEvent bitbucketEvent = createEvent(event, action);
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketEventTest.java
@@ -84,6 +84,28 @@ public class BitbucketEventTest {
     }
 
     @Test
+    public void testPullRequestEventUpdatedAction() {
+        String event = "pullrequest";
+        String action = "updated";
+
+        BitbucketEvent bitbucketEvent = createEvent(event, action);
+
+        assertEquals(event, bitbucketEvent.getName());
+        assertEquals(action, bitbucketEvent.getAction());
+    }
+
+    @Test
+    public void testPullRequestEventMergedAction() {
+        String event = "pullrequest";
+        String action = "merged";
+
+        BitbucketEvent bitbucketEvent = createEvent(event, action);
+
+        assertEquals(event, bitbucketEvent.getName());
+        assertEquals(action, bitbucketEvent.getAction());
+    }
+
+    @Test
     public void testPullRequestEventApprovedAction() {
         String event = "pullrequest";
         String action = "approved";

--- a/src/test/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtensionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/extensions/dsl/BitbucketHookJobDslExtensionTest.java
@@ -28,6 +28,8 @@ import com.cloudbees.jenkins.plugins.BitBucketTrigger;
 import com.cloudbees.jenkins.plugins.filter.BitbucketTriggerFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestApprovedActionFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestCreatedActionFilter;
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestUpdatedActionFilter;
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestMergedActionFilter;
 import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestTriggerFilter;
 import com.cloudbees.jenkins.plugins.filter.repository.RepositoryPushActionFilter;
 import com.cloudbees.jenkins.plugins.filter.repository.RepositoryTriggerFilter;
@@ -182,6 +184,68 @@ public class BitbucketHookJobDslExtensionTest {
                         if (bitbucketTriggerFilter instanceof PullRequestTriggerFilter) {
                             PullRequestTriggerFilter pullRequestTriggerFilter = (PullRequestTriggerFilter) bitbucketTriggerFilter;
                             assertEquals(pullRequestTriggerFilter.getActionFilter() instanceof PullRequestCreatedActionFilter, true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBitbucketPullRequestUpdatedAction() throws Exception {
+        TopLevelItem topLevelItem = jenkinsRule.getInstance().createProjectFromXML("whatever",
+                new ByteArrayInputStream((getJobDSLTrigger("freeStyleJob('test-job') { triggers{ bitbucketPullRequestUpdatedAction(false) } }\n")).getBytes()));
+        if (topLevelItem instanceof FreeStyleProject) {
+            FreeStyleProject freeStyleProject = (FreeStyleProject) topLevelItem;
+            Future<FreeStyleBuild> build = freeStyleProject.scheduleBuild2(0, new Cause.UserCause());
+            build.get(); //// let mock build finish
+        }
+        TopLevelItem whateverTopLevelItem = jenkinsRule.getInstance().getItem("test-job");
+        if (whateverTopLevelItem instanceof FreeStyleProject) {
+            FreeStyleProject whateverFreeStyleProject = (FreeStyleProject) whateverTopLevelItem;
+            Map<TriggerDescriptor, Trigger<?>> triggers = whateverFreeStyleProject.getTriggers();
+            assertEquals(triggers.size(), 1);
+            for (Map.Entry<TriggerDescriptor, Trigger<?>> entry : triggers.entrySet()) {
+                if(entry.getValue() instanceof BitBucketTrigger) {
+                    BitBucketTrigger bitBucketTrigger = (BitBucketTrigger) entry.getValue();
+                    List<BitbucketTriggerFilter> bitbucketTriggerFilters = bitBucketTrigger.getTriggers();
+                    assertEquals(bitbucketTriggerFilters.size(), 1);
+                    for (BitbucketTriggerFilter bitbucketTriggerFilter : bitbucketTriggerFilters) {
+                        assertEquals(bitbucketTriggerFilter instanceof PullRequestTriggerFilter, true);
+                        if (bitbucketTriggerFilter instanceof PullRequestTriggerFilter) {
+                            PullRequestTriggerFilter pullRequestTriggerFilter = (PullRequestTriggerFilter) bitbucketTriggerFilter;
+                            assertEquals(pullRequestTriggerFilter.getActionFilter() instanceof PullRequestUpdatedActionFilter, true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBitbucketPullRequestMergedAction() throws Exception {
+        TopLevelItem topLevelItem = jenkinsRule.getInstance().createProjectFromXML("whatever",
+                new ByteArrayInputStream((getJobDSLTrigger("freeStyleJob('test-job') { triggers{ bitbucketPullRequestMergedAction(false) } }\n")).getBytes()));
+        if (topLevelItem instanceof FreeStyleProject) {
+            FreeStyleProject freeStyleProject = (FreeStyleProject) topLevelItem;
+            Future<FreeStyleBuild> build = freeStyleProject.scheduleBuild2(0, new Cause.UserCause());
+            build.get(); //// let mock build finish
+        }
+        TopLevelItem whateverTopLevelItem = jenkinsRule.getInstance().getItem("test-job");
+        if (whateverTopLevelItem instanceof FreeStyleProject) {
+            FreeStyleProject whateverFreeStyleProject = (FreeStyleProject) whateverTopLevelItem;
+            Map<TriggerDescriptor, Trigger<?>> triggers = whateverFreeStyleProject.getTriggers();
+            assertEquals(triggers.size(), 1);
+            for (Map.Entry<TriggerDescriptor, Trigger<?>> entry : triggers.entrySet()) {
+                if(entry.getValue() instanceof BitBucketTrigger) {
+                    BitBucketTrigger bitBucketTrigger = (BitBucketTrigger) entry.getValue();
+                    List<BitbucketTriggerFilter> bitbucketTriggerFilters = bitBucketTrigger.getTriggers();
+                    assertEquals(bitbucketTriggerFilters.size(), 1);
+                    for (BitbucketTriggerFilter bitbucketTriggerFilter : bitbucketTriggerFilters) {
+                        assertEquals(bitbucketTriggerFilter instanceof PullRequestTriggerFilter, true);
+                        if (bitbucketTriggerFilter instanceof PullRequestTriggerFilter) {
+                            PullRequestTriggerFilter pullRequestTriggerFilter = (PullRequestTriggerFilter) bitbucketTriggerFilter;
+                            assertEquals(pullRequestTriggerFilter.getActionFilter() instanceof PullRequestMergedActionFilter, true);
                         }
                     }
                 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/filter/PullRequestTriggerFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/filter/PullRequestTriggerFilterTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 CloudBees, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins;
 
 import org.junit.Test;
@@ -15,10 +39,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
 import static org.mockito.Matchers.*;
-
-/**
- * Created by Douglas Miller on 2016/06/13.
- */
 
 @RunWith(MockitoJUnitRunner.class)
 public class PullRequestTriggerFilterTest {

--- a/src/test/java/com/cloudbees/jenkins/plugins/filter/PullRequestTriggerFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/filter/PullRequestTriggerFilterTest.java
@@ -1,0 +1,137 @@
+package com.cloudbees.jenkins.plugins;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestCreatedActionFilter;
+import com.cloudbees.jenkins.plugins.filter.pullrequest.PullRequestTriggerFilter;
+import com.cloudbees.jenkins.plugins.payload.BitbucketPayload;
+import net.sf.json.JSONObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+
+/**
+ * Created by Douglas Miller on 2016/06/13.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class PullRequestTriggerFilterTest {
+    @Mock
+    private PullRequestCreatedActionFilter actionFilter;
+
+    @Mock
+    private BitbucketPayload bitbucketPayload;
+
+    @Test
+    public void testSetDefaultTargetBranch() {
+        String targetBranch = "";
+        String defaultTargetBranch = "**";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch);
+
+        assertEquals(defaultTargetBranch, triggerFilter.getPullRequestTargetBranch());
+    }
+
+    @Test
+    public void testSetTargetBranch() {
+        String targetBranch = "develop, master";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch);
+
+        assertEquals(targetBranch, triggerFilter.getPullRequestTargetBranch());
+    }
+
+    @Test
+    public void testShouldScheduleJob() {
+        String targetBranch = "develop, master";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "develop");
+
+        assertTrue(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    @Test
+    public void testShouldNotScheduleJob() {
+        String targetBranch = "master";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "develop");
+
+        assertFalse(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    @Test
+    public void testShouldScheduleWildcardJob() {
+        String targetBranch = "*/2.0";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "release/2.0");
+
+        assertTrue(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    @Test
+    public void testShouldNotScheduleWildcardJob() {
+        String targetBranch = "*2.0";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "release/2.0");
+
+        assertFalse(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    @Test
+    public void testShouldScheduleDoubleWildcardJob() {
+        String targetBranch = "**2.0";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "release/2.0");
+
+        assertTrue(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    @Test
+    public void testShouldNotScheduleDoubleWildcardJob() {
+        String targetBranch = "**master";
+
+        PullRequestTriggerFilter triggerFilter = createTriggerFilter(targetBranch, "release/2.0");
+
+        assertFalse(triggerFilter.shouldScheduleJob(bitbucketPayload));
+    }
+
+    private PullRequestTriggerFilter createTriggerFilter(String pullRequestTargetBranch) {
+      return createTriggerFilter(pullRequestTargetBranch, "");
+    }
+
+    private PullRequestTriggerFilter createTriggerFilter(String pullRequestTargetBranch, String destinationBranch) {
+        when(
+          actionFilter.shouldTriggerBuild(
+            any(BitbucketPayload.class)
+          )
+        ).thenReturn(true);
+
+        when(bitbucketPayload.getPayload()).thenReturn(jsonObject(destinationBranch));
+
+        PullRequestTriggerFilter triggerFilter = new PullRequestTriggerFilter(actionFilter, pullRequestTargetBranch);
+
+        return triggerFilter;
+    }
+
+    private JSONObject jsonObject(String destinationBranch) {
+        JSONObject branch = new JSONObject();
+        branch.put("name", destinationBranch);
+
+        JSONObject destination = new JSONObject();
+        destination.put("branch", branch);
+
+        JSONObject pullrequest = new JSONObject();
+        pullrequest.put("destination", destination);
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("pullrequest", pullrequest);
+
+        return jsonObject;
+    }
+}


### PR DESCRIPTION
This pull request expands on the changes made by @Shyri in #28 and #29.

I have added the ability to filter by the pull request destination branch. This functionality was based on the Git Plugin's branch filtering wildcards \* and **.

I have also added support for Updated and Merged pull request hooks from bitbucket.

I know that @jrtheinert mentioned a desire to expand on @Shyri's original PR. I hope that these additions can help with that.

I should provide a disclaimer that I haven't written much Java lately. Please let me know if there is anything that I should update.
