### PR TITLE
Use the project quiet period for the schedule build

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
@@ -104,13 +104,21 @@ public class BitBucketTrigger extends Trigger<Job<?, ?>> {
             }
         };
 
-        pJob.scheduleBuild2(5, new CauseAction(cause), bitbucketPayload);
+        pJob.scheduleBuild2(getQuietPeriod(), new CauseAction(cause), bitbucketPayload);
         if (pJob.scheduleBuild(cause)) {
             String name = " #" + job.getNextBuildNumber();
             LOGGER.info("SCM changes detected in " + job.getName() + ". Triggering " + name);
         } else {
             LOGGER.info("SCM changes detected in " + job.getName() + ". Job is already in the queue");
         }
+    }
+
+    private int getQuietPeriod() {
+        int quietPeriod = 5;
+        if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
+            quietPeriod = ((ParameterizedJobMixIn.ParameterizedJob) job).getQuietPeriod();
+        }
+        return quietPeriod > 5 ? quietPeriod : 5;
     }
 
     @Override


### PR DESCRIPTION
Hello,

When working with multiple repositories, its good to use the quiet period to avoid incomplete builds.

Any reason to hardcoded it to 5 seconds? Why to not use the quiet period param from the project?

I've added a change to use the project quiet period if it exists.

Thank you,
Anderson Topine
