### PR TITLE
Fix: Bitbucket push can now kick off Jenkins Pipeline Jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.40</version>
+            <version>1.66</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
This change though minimal would have massive positive effects for me and my team. Pipeline Jobs have not been able to be kicked of unless using the Bitbucket Branch Source Plugin which is far from straightforward. 

Please merge this change.