### PR TITLE
New Branch: Scan multibranch pipeline log

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -9,11 +9,9 @@ import hudson.scm.SCM;
 import hudson.security.ACL;
 
 import java.net.URISyntaxException;
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -22,7 +20,6 @@ import jenkins.model.Jenkins;
 
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.triggers.SCMTriggerItem;


### PR DESCRIPTION
The
```
 triggers{
    bitbucketPush()
  }
```
is useful for standalone jenkinsfile projects and single branches of a multibranch project,
but when having a
* Multibranch Project

and pushing a new branch, the BitBucket WebTrigger is sending a push, but the
BitbucketJobProbe is checking for the update of "Job.class" only.

The "Scan Multibranch Pipeline Log" is not triggered (to find the new branch).
Workaround is to klick on "Scan Multibranch Pipeline Now" each time a new branch in created.

As this happens often when using git flow on that project I fixed the detection to search for all
"SCMSourceOwner.class" als well (which includes MultiBranchProject.class) where the URL is matching the configured one and then invoke "onSCMSourceUpdated".

As "SCMTriggerItem" has an SCM directly inside and the SCMSourceOwner just has a SCMSource I refactored the 2 "match" blocks to a method detecting the match based on the URIish.
(that's why it looks like to be more changes, but the block itself is unchanged)

 