### PR TITLE
Added support to detect trigger for repos that end with .git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>bitbucket</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Bitbucket Plugin</name>
     <description>integrate Jenkins with BitBucket.</description>
@@ -18,7 +18,7 @@
         <connection>scm:git:git://github.com/jenkinsci/bitbucket-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/bitbucket-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/bitbucket-plugin</url>
-        <tag>bitbucket-1.1.12</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>bitbucket</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.12</version>
     <packaging>hpi</packaging>
     <name>Jenkins Bitbucket Plugin</name>
     <description>integrate Jenkins with BitBucket.</description>
@@ -18,7 +18,7 @@
         <connection>scm:git:git://github.com/jenkinsci/bitbucket-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/bitbucket-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/bitbucket-plugin</url>
-        <tag>HEAD</tag>
+        <tag>bitbucket-1.1.12</tag>
     </scm>
 
     <properties>

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -98,10 +98,15 @@ public class BitbucketJobProbe {
                     if (StringUtils.isEmpty(url.getHost())) {
                     	urIish = urIish.setHost(url.getHost());
                     }
-                    
+
                     LOGGER.log(Level.FINE, "Trying to match {0} ", urIish.toString() + "<-->" + url.toString());
                     if (GitStatus.looselyMatches(urIish, url)) {
                         return true;
+                    } else if ( urIish.getPath().endsWith(".git.git")){
+                        LOGGER.log(Level.FINE, "Repo ends with .git.git, removing last .git");
+                        urIish = urIish.setPath(urIish.getPath().substring(0,urIish.getPath().length()-4));
+                        LOGGER.log(Level.FINE, "Trying to match {0} ", urIish.toString() + "<-->" + url.toString());
+                        return GitStatus.looselyMatches(urIish, url);
                     }
                 }
             }


### PR DESCRIPTION
Fixed trigger not detecting Jenkins Job in case the repo URL ends with .git, for example tzach.git