### PR TITLE
doc: Fix readme example for overrideUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ freeStyleJob('test-job') {
 ### Job DSL example for overrideUrl
 ```
 triggers{
-  bitbucketPush{
-    overrideUrl('https://bitbucket.org/blabla/hello-world-server')
-  }
+  bitbucketPush overrideUrl: 'https://bitbucket.org/blabla/hello-world-server'
 }
 ```
 


### PR DESCRIPTION
Fixed README.md example with `overrideUrl`. Previous examples throw compilation error below :

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 5: Triggers definitions cannot have blocks @ line 5, column 9.
           bitbucketPush {
           ^

1 error
```