### PR TITLE
JENKINS-41635 - fixed. BITBUCKET_PAYLOAD environment variable is now available in pipelines also

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ triggers{
 ```
 
 **Changelog**
+#### TBD #### (26. Feb 2022)
+- JENKINS-41635 - fixed. This required a change in Jenkins minimum version from 2.204.1 to 2.303.1
+
 #### 215.vfe32d14d1f47 #### (04. Feb 2022)
 - Fixed NPE
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!--        <spotbugs.skip>true</spotbugs.skip>-->
-        <jenkins.version>2.204.1</jenkins.version>
+        <jenkins.version>2.303.1</jenkins.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.level>8</java.level>

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPayload.java
@@ -1,9 +1,10 @@
 package com.cloudbees.jenkins.plugins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
-import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.InvisibleAction;
+import hudson.model.Run;
 
 import javax.annotation.Nonnull;
 import java.util.logging.Level;
@@ -27,10 +28,11 @@ public class BitBucketPayload extends InvisibleAction implements EnvironmentCont
     }
 
     @Override
-    public void buildEnvVars(AbstractBuild<?, ?> abstractBuild, EnvVars envVars) {
+    public void buildEnvironment(@NonNull Run<?, ?> run, @NonNull EnvVars env) {
+        EnvironmentContributingAction.super.buildEnvironment(run, env);
         final String payload = getPayload();
         LOGGER.log(Level.FINEST, "Injecting BITBUCKET_PAYLOAD: {0}", payload);
-        envVars.put("BITBUCKET_PAYLOAD", payload);
+        env.put("BITBUCKET_PAYLOAD", payload);
     }
 
     private static final Logger LOGGER = Logger.getLogger(BitBucketPayload.class.getName());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira - https://issues.jenkins.io/browse/JENKINS-41635
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

https://issues.jenkins.io/browse/JENKINS-41635
