### PR TITLE
Fix Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ triggers{
 ```
 
 **Changelog**
-#### 223.vd12f2bca5430 #### (26. Feb 2022)
+#### 223.vd12f2bca5430 (26. Feb 2022)
 - JENKINS-41635 - fixed. This required a change in Jenkins minimum version from 2.204.1 to 2.303.1
 
-#### 215.vfe32d14d1f47 #### (04. Feb 2022)
+#### 215.vfe32d14d1f47 (04. Feb 2022)
 - Fixed NPE
 
 #### 1.1.30 (20. Nov 2021)


### PR DESCRIPTION
This looked unintentional. The second set of `#` need to be end of line to be invisible.
