### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPayload.java
@@ -6,7 +6,6 @@ import hudson.model.EnvironmentContributingAction;
 import hudson.model.InvisibleAction;
 import hudson.model.Run;
 
-import javax.annotation.Nonnull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -16,13 +15,13 @@ import java.util.logging.Logger;
  * @version 1.1.5
  */
 public class BitBucketPayload extends InvisibleAction implements EnvironmentContributingAction {
-    private final @Nonnull String payload;
+    private final @NonNull String payload;
 
-    public BitBucketPayload(@Nonnull String payload) {
+    public BitBucketPayload(@NonNull String payload) {
         this.payload = payload;
     }
 
-    @Nonnull
+    @NonNull
     public String getPayload() {
         return payload;
     }


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Spotbugs annotations were already imported in the source file that was still using a JSR-305 annotation.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
