### PR TITLE
JENKINS-69490 - fix - check if item is null before printing the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ triggers{
 
 **Changelog**
 
+#### TBD ####
+- JENKINS-69490 - fixed NPE when using pipeline-syntax properties: Set job properties
+
 #### 237.vc424f493c5f6 (10. Dec 2023)
 - JENKINS-72448 - Updated jenkins.version from 2.375.3 to 2.414.1
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketMultibranchTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketMultibranchTrigger.java
@@ -45,7 +45,9 @@ public class BitBucketMultibranchTrigger extends Trigger<WorkflowMultiBranchProj
 
         @Override
         public boolean isApplicable(Item item) {
-            LOGGER.finest(item.getClass().getSimpleName());
+            if ( item != null){
+                LOGGER.finest(item.getClass().getSimpleName());
+            }
             return item instanceof WorkflowMultiBranchProject;
         }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix NPE when calling Properties: Set Job properties in pipeline-syntax. 
See https://issues.jenkins.io/browse/JENKINS-69490 for more details

### Testing done

Tested using `mvnDebug hpi:run` and saw code is stopped on breakpoint. 
Verified with and without the fix

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
