### PR TITLE
Small improvements and fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-bitbucket-branch-source</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -17,7 +17,7 @@ import org.kohsuke.stapler.StaplerRequest2;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension
-public class BitbucketHookReceiver implements UnprotectedRootAction {
+public class BitbucketHookReceiver extends BitbucketCrumbExclusion implements UnprotectedRootAction {
 
     private final BitbucketPayloadProcessor payloadProcessor = new BitbucketPayloadProcessor();
     public static final String BITBUCKET_HOOK_URL = "bitbucket-hook";

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -66,7 +66,7 @@ public class BitbucketJobProbe {
                                 bTrigger = (BitBucketTrigger) trigger;
                                 LOGGER.log(Level.FINE, "Job [{0}] has BitBucketTrigger", job.getName());
                                 break;
-                            } else if ( trigger instanceof BitBucketMultibranchTrigger){
+                            } else if (trigger instanceof BitBucketMultibranchTrigger) {
                                 LOGGER.fine("Trigger is BitBucketMultibranchTrigger");
                             }
                         }
@@ -108,7 +108,7 @@ public class BitbucketJobProbe {
                                 LOGGER.finest("scmSourceOwner [" + scmSourceOwner.getName() + "] is of type WorkflowMultiBranchProject");
                                 WorkflowMultiBranchProject workflowMultiBranchProject  = (WorkflowMultiBranchProject) scmSourceOwner;
                                 AtomicReference<BitBucketMultibranchTrigger> bitBucketMultibranchTrigger = new AtomicReference<>(null);
-                                if ( workflowMultiBranchProject.getTriggers().isEmpty()) {
+                                if (workflowMultiBranchProject.getTriggers().isEmpty()) {
                                     LOGGER.finest("No triggers found");
                                 } else {
                                     workflowMultiBranchProject.getTriggers().forEach(((triggerDescriptor, trigger) -> {
@@ -118,10 +118,10 @@ public class BitbucketJobProbe {
                                         }
                                     }));
                                 }
-                                if ( bitBucketMultibranchTrigger.get() == null){
+                                if (bitBucketMultibranchTrigger.get() == null) {
                                     scmSourceOwner.onSCMSourceUpdated(scmSource);
                                 } else {
-                                    if (workflowMultiBranchProject.isBuildable()){
+                                    if (workflowMultiBranchProject.isBuildable()) {
                                         bitBucketMultibranchTrigger.get().setPayload(payload);
                                         BitBucketPushCause bitBucketPushCause = new BitBucketPushCause(user);
                                         workflowMultiBranchProject.scheduleBuild2(0, new CauseAction(bitBucketPushCause));
@@ -135,19 +135,19 @@ public class BitbucketJobProbe {
                         } else if (scmSourceOwner instanceof WorkflowMultiBranchProject) {
                             LOGGER.finest("scmSourceOwner [" + scmSourceOwner.getName() + "] is of type WorkflowMultiBranchProject");
                             WorkflowMultiBranchProject workflowMultiBranchProject = (WorkflowMultiBranchProject) scmSourceOwner;
-                            if ( workflowMultiBranchProject.getTriggers().isEmpty()){
+                            if (workflowMultiBranchProject.getTriggers().isEmpty()) {
                                 LOGGER.finest("No triggers found");
                             } else {
                                 workflowMultiBranchProject.getTriggers().forEach(((triggerDescriptor, trigger) -> {
-                                    if ( trigger instanceof BitBucketMultibranchTrigger){
+                                    if (trigger instanceof BitBucketMultibranchTrigger) {
                                         LOGGER.finest("Found BitBucketMultibranchTrigger type");
                                         BitBucketMultibranchTrigger bitBucketMultibranchTrigger = (BitBucketMultibranchTrigger) trigger;
-                                        if ( bitBucketMultibranchTrigger.getOverrideUrl() == null || bitBucketMultibranchTrigger.getOverrideUrl().isEmpty()){
+                                        if (bitBucketMultibranchTrigger.getOverrideUrl() == null || bitBucketMultibranchTrigger.getOverrideUrl().isEmpty()) {
                                             LOGGER.finest("Ignoring empty overrideUrl");
                                         } else {
                                             LOGGER.fine("Found override URL [" + bitBucketMultibranchTrigger.getOverrideUrl() + "]");
                                             LOGGER.log(Level.FINE, "Trying to match {0} ", remote + "<-->" + bitBucketMultibranchTrigger.getOverrideUrl());
-                                            if ( bitBucketMultibranchTrigger.getOverrideUrl().equalsIgnoreCase(remote.toString())) {
+                                            if (bitBucketMultibranchTrigger.getOverrideUrl().equalsIgnoreCase(remote.toString())) {
                                                 LOGGER.info(String.format("Triggering BitBucket scmSourceOwner [%s] by overrideUrl [%s]",scmSourceOwner.getName(), bitBucketMultibranchTrigger.getOverrideUrl()));
                                                 scmSourceOwner.onSCMSourceUpdated(scmSource);
                                             }


### PR DESCRIPTION
We established a Jenkins multibranch pipeline project to monitor multiple Bitbucket repositories, specifically designed for building complex operating systems like Yocto. This setup leverages the Jenkins Remote File Provider plugin (https://plugins.jenkins.io/remote-file/) to enable the use of a single Jenkinsfile across all monitored repositories (e.g., meta-company, meta-extra-company).

Our infrastructure includes Jenkins behind a firewall, which initially caused webhook crumb issues. To resolve this, we employed smee.io to bypass the firewall and facilitate reliable webhook delivery from Bitbucket Cloud to Jenkins.

The Jenkins instance utilizes the Bitbucket Branch Source plugin, resulting in requests being processed as BitbucketSCMSource. This source, however, lacked the getRemote method, requiring specific patches for proper functionality.

### Testing done ###

Testing was conducted within our infrastructure, confirming successful build triggering upon both push and pull request events from Bitbucket Cloud to our firewall-protected Jenkins instance