### PR TITLE
Jenkins 73111 - add support for HMAC secret

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTrigger.java
@@ -10,6 +10,7 @@ import hudson.model.Job;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import hudson.util.SequentialExecutionQueue;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
@@ -35,6 +36,7 @@ public class BitBucketTrigger extends Trigger<Job<?, ?>> {
 
     private String overrideUrl;
     private Boolean buildOnCreatedBranch;
+    private Secret webhookSecret;
 
     @DataBoundConstructor
     public BitBucketTrigger() { }
@@ -56,6 +58,19 @@ public class BitBucketTrigger extends Trigger<Job<?, ?>> {
     @DataBoundSetter
     public void setBuildOnCreatedBranch(Boolean buildOnCreatedBranch) {
         this.buildOnCreatedBranch = buildOnCreatedBranch;
+    }
+
+    public Secret getWebhookSecret() {
+        return webhookSecret;
+    }
+
+    @DataBoundSetter
+    public void setWebhookSecret(Secret webhookSecret) {
+        this.webhookSecret = webhookSecret;
+    }
+
+    public String getWebhookSecretPlainText() {
+        return Secret.toString(webhookSecret);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketHookReceiver.java
@@ -1,17 +1,18 @@
 package com.cloudbees.jenkins.plugins;
 
-import hudson.Extension;
-import hudson.model.UnprotectedRootAction;
-
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sf.json.JSONObject;
-
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import net.sf.json.JSONObject;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -39,19 +40,26 @@ public class BitbucketHookReceiver extends BitbucketCrumbExclusion implements Un
      * as form-urlencoded <pre>payload=JSON</pre>
      * @throws IOException
      */
-    public void doIndex(StaplerRequest2 req) throws IOException {
-        String body = IOUtils.toString(req.getInputStream());
+    public void doIndex(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        byte[] bodyBytes = IOUtils.toByteArray(req.getInputStream());
+        String body = new String(bodyBytes, StandardCharsets.UTF_8);
         if (!body.isEmpty() && req.getRequestURI().contains("/" + BITBUCKET_HOOK_URL + "/")) {
             String contentType = req.getContentType();
             if (contentType != null && contentType.startsWith("application/x-www-form-urlencoded")) {
-                body = URLDecoder.decode(body);
+                body = URLDecoder.decode(body, StandardCharsets.UTF_8);
             }
             if (body.startsWith("payload=")) body = body.substring(8);
 
             LOGGER.log(Level.FINE, "Received commit hook notification : {0}", body);
             JSONObject payload = JSONObject.fromObject(body);
 
-            payloadProcessor.processPayload(payload, req);
+            BitbucketWebhookResult result = payloadProcessor.processPayload(payload, req, bodyBytes);
+            if (result == BitbucketWebhookResult.INVALID_SIGNATURE) {
+                LOGGER.log(Level.WARNING, "Rejected Bitbucket webhook with invalid or missing X-Hub-Signature");
+                rsp.sendError(403, "Invalid Bitbucket webhook signature");
+            } else if (result == BitbucketWebhookResult.NO_MATCH) {
+                LOGGER.log(Level.WARNING, "No matching Jenkins job or multibranch project was found for the Bitbucket webhook");
+            }
         } else {
             LOGGER.log(Level.WARNING, "The Jenkins job cannot be triggered. You might not have configured correctly the WebHook on BitBucket with the last slash `http://<JENKINS-URL>/bitbucket-hook/` or a 'Test connection' invocation of the hook was triggered.");
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -46,15 +46,19 @@ public class BitbucketJobProbe {
         }
     }
 
-    public void triggerMatchingJobs(String user, String url, String scm, String payload) {
-        triggerMatchingJobs(user, url, scm, payload, null);
+    public BitbucketWebhookResult triggerMatchingJobs(String user, String url, String scm, String payload) {
+        return triggerMatchingJobs(user, url, scm, payload, null, null, null);
     }
 
-    public void triggerMatchingJobs(String user, String url, String scm, String payload, String branchName) {
+    public BitbucketWebhookResult triggerMatchingJobs(String user, String url, String scm, String payload, String branchName, String signatureHeader, byte[] bodyBytes) {
         if ("git".equals(scm) || "hg".equals(scm)) {
             SecurityContext old = Jenkins.getInstance().getACL().impersonate2(ACL.SYSTEM2);
             try {
                 URIish remote = new URIish(url);
+                boolean matchingProtectedJobFound = false;
+                boolean signatureRejectedForMatchingJob = false;
+                boolean acceptedMatchingJobFound = false;
+                boolean matchingJobFound = false;
                 for (Job<?, ?> job : Jenkins.getInstance().getAllItems(Job.class)) {
                     BitBucketTrigger bTrigger = null;
                     LOGGER.log(Level.FINE, "Considering candidate job [{0}]", job.getName());
@@ -87,9 +91,18 @@ public class BitbucketJobProbe {
                             }
                             for (SCM scmTrigger : item.getSCMs()) {
                                 if (match(scmTrigger, remote, bTrigger.getOverrideUrl()) && !hasBeenTriggered(scmTriggered, scmTrigger)) {
-                                    LOGGER.log(Level.FINER, "Triggering BitBucket job {0}", job.getFullDisplayName());
-                                    scmTriggered.add(scmTrigger);
-                                    bTrigger.onPost(user, payload, branchName);
+                                    matchingJobFound = true;
+                                    if (shouldTriggerForSignature(job, bTrigger, signatureHeader, bodyBytes)) {
+                                        LOGGER.log(Level.FINER, "Triggering BitBucket job {0}", job.getFullDisplayName());
+                                        scmTriggered.add(scmTrigger);
+                                        acceptedMatchingJobFound = true;
+                                        bTrigger.onPost(user, payload, branchName);
+                                    } else {
+                                        signatureRejectedForMatchingJob = true;
+                                        if (hasWebhookSecret(bTrigger)) {
+                                            matchingProtectedJobFound = true;
+                                        }
+                                    }
                                 } else {
                                     LOGGER.log(Level.FINEST, String.format("[%s] SCM doesn't match remote repo [%s]", job.getName(), remote));
                                 }
@@ -104,6 +117,7 @@ public class BitbucketJobProbe {
                     for (SCMSource scmSource : scmSources) {
                         LOGGER.log(Level.FINER, "Considering candidate scmSource {0}", scmSource);
                         if (match(scmSource, remote)) {
+                            matchingJobFound = true;
                             if (scmSourceOwner instanceof WorkflowMultiBranchProject) {
                                 LOGGER.finest("scmSourceOwner [" + scmSourceOwner.getName() + "] is of type WorkflowMultiBranchProject");
                                 WorkflowMultiBranchProject workflowMultiBranchProject  = (WorkflowMultiBranchProject) scmSourceOwner;
@@ -163,6 +177,18 @@ public class BitbucketJobProbe {
                         }
                     }
                 }
+                if (acceptedMatchingJobFound) {
+                    return BitbucketWebhookResult.TRIGGERED;
+                }
+                if (matchingProtectedJobFound || signatureRejectedForMatchingJob) {
+                    return BitbucketWebhookResult.INVALID_SIGNATURE;
+                }
+                if (!matchingJobFound) {
+                    LOGGER.log(Level.WARNING, "No Jenkins job or multibranch project matched repository [{0}]", url);
+                    return BitbucketWebhookResult.NO_MATCH;
+                }
+                LOGGER.log(Level.WARNING, "Bitbucket webhook matched Jenkins items for repository [{0}] but did not trigger a build", url);
+                return BitbucketWebhookResult.NO_MATCH;
             } catch (URISyntaxException e) {
                 LOGGER.log(Level.WARNING, "Invalid repository URL {0}", url);
             } finally {
@@ -172,6 +198,35 @@ public class BitbucketJobProbe {
         } else {
             throw new UnsupportedOperationException("Unsupported SCM type " + scm);
         }
+        return BitbucketWebhookResult.IGNORED;
+    }
+
+    private boolean shouldTriggerForSignature(Job<?, ?> job, BitBucketTrigger trigger, String signatureHeader, byte[] bodyBytes) {
+        String secret = trigger.getWebhookSecretPlainText();
+        if (secret == null || secret.isBlank()) {
+            if (signatureHeader != null && !signatureHeader.isBlank()) {
+                LOGGER.log(Level.WARNING, "Job [{0}] has no webhook secret configured, but X-Hub-Signature header was provided", job.getName());
+                return false;
+            }
+            LOGGER.log(Level.FINE, "Job [{0}] has no webhook secret configured; accepting request without signature validation", job.getName());
+            return true;
+        }
+
+        if (signatureHeader == null || signatureHeader.isBlank()) {
+            LOGGER.log(Level.FINE, "Job [{0}] has a webhook secret configured, but X-Hub-Signature header is missing", job.getName());
+            return false;
+        }
+
+        boolean valid = BitbucketWebhookSignatureValidator.isValidSignature(signatureHeader, secret, bodyBytes);
+        if (!valid) {
+            LOGGER.log(Level.FINE, "Job [{0}] webhook signature did not validate", job.getName());
+        }
+        return valid;
+    }
+
+    private boolean hasWebhookSecret(BitBucketTrigger trigger) {
+        String secret = trigger.getWebhookSecretPlainText();
+        return secret != null && !secret.isBlank();
     }
 
     private boolean hasBeenTriggered(List<SCM> scmTriggered, SCM scmTrigger) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessor.java
@@ -24,39 +24,40 @@ public class BitbucketPayloadProcessor {
         this(new BitbucketJobProbe());
     }
 
-    public void processPayload(JSONObject payload, HttpServletRequest request) {
+    public BitbucketWebhookResult processPayload(JSONObject payload, HttpServletRequest request, byte[] bodyBytes) {
         if ("Bitbucket-Webhooks/2.0".equals(request.getHeader("user-agent"))) {
             if ("repo:push".equals(request.getHeader("x-event-key"))) {
                 LOGGER.log(Level.FINER, "Processing new Webhooks payload");
-                processWebhookPayload(payload);
+                return processWebhookPayload(payload, request, bodyBytes);
             }
         } else if (payload.has("actor") && payload.has("repository") && payload.getJSONObject("repository").has("links")) {
             if ("repo:push".equals(request.getHeader("x-event-key"))) {
                 // found web hook according to https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/
                 LOGGER.log(Level.FINER, "Processing new Cloud Webhooks payload");
-                processWebhookPayloadBitBucketServer(payload);
+                return processWebhookPayloadBitBucketServer(payload, request, bodyBytes);
             } else if ("repo:refs_changed".equals(request.getHeader("x-event-key"))) {
                 // found web hook according to https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
                 LOGGER.log(Level.FINER, "Processing new Self Hosted Server Webhooks payload");
-                processWebhookPayloadBitBucketSelfHosted(payload);
+                return processWebhookPayloadBitBucketSelfHosted(payload, request, bodyBytes);
             } else {
                 LOGGER.log(Level.FINER, "Unsupported [x-event-key] value, [x-event-key] is [" + request.getHeader("x-event-key") + "]");
             }
         } else if (payload.has("actor")) {
         	// we assume that the passed hook was from bitbucket server https://confluence.atlassian.com/bitbucketserver/managing-webhooks-in-bitbucket-server-938025878.html
         	LOGGER.log(Level.FINER, "Processing webhook for self-hosted bitbucket instance");
-        	processWebhookPayloadBitBucketSelfHosted(payload);
+        	return processWebhookPayloadBitBucketSelfHosted(payload, request, bodyBytes);
         } else {
             // https://github.com/jenkinsci/bitbucket-plugin/pull/65
             if ("diagnostics:ping".equals(request.getHeader("x-event-key"))) {
                 if (payload.has("test") && payload.getBoolean("test")) {
                     LOGGER.log(Level.FINER, "Bitbucket test connection payload");
-                    return;
+                    return BitbucketWebhookResult.IGNORED;
                 }
             }
             LOGGER.log(Level.FINER, "Processing old POST service payload");
-            processPostServicePayload(payload);
+            return processPostServicePayload(payload, request, bodyBytes);
         }
+        return BitbucketWebhookResult.IGNORED;
     }
 
     /**
@@ -67,7 +68,7 @@ public class BitbucketPayloadProcessor {
      * 
      * @param payload The payload matching the definition in https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html
      */
-    private void processWebhookPayloadBitBucketSelfHosted(JSONObject payload) {
+    private BitbucketWebhookResult processWebhookPayloadBitBucketSelfHosted(JSONObject payload, HttpServletRequest request, byte[] bodyBytes) {
     	JSONObject repo;
     	
     	// find the repository hidden in different objects
@@ -78,7 +79,7 @@ public class BitbucketPayloadProcessor {
     	} else {
     		LOGGER.log(Level.WARNING, "Not possible to trigger job for event '{0}'. Only PR events and pushes are supported for now.", payload.get("eventKey"));
     		LOGGER.log(Level.FINE, payload.toString());
-    		return;
+    		return BitbucketWebhookResult.IGNORED;
     	}
     	
         String user = payload.getJSONObject("actor").getString("name");
@@ -86,11 +87,11 @@ public class BitbucketPayloadProcessor {
 
         // always use git no other repo type supported on self-hosted solution
         String scm = "git";
-        probe.triggerMatchingJobs(user, url, scm, payload.toString());
+        return probe.triggerMatchingJobs(user, url, scm, payload.toString(), null, request.getHeader("X-Hub-Signature"), bodyBytes);
 		
 	}
 
-	private void processWebhookPayload(JSONObject payload) {
+	private BitbucketWebhookResult processWebhookPayload(JSONObject payload, HttpServletRequest request, byte[] bodyBytes) {
         if (isPayloadOldMemberNull(payload)){
             String branchName = getBranchName(payload);
             JSONObject repo = payload.getJSONObject("repository");
@@ -99,7 +100,7 @@ public class BitbucketPayloadProcessor {
             String url = repo.getJSONObject("links").getJSONObject("html").getString("href");
             String scm = repo.has("scm") ? repo.getString("scm") : "git";
 
-            probe.triggerMatchingJobs(user, url, scm, payload.toString(), branchName);
+            return probe.triggerMatchingJobs(user, url, scm, payload.toString(), branchName, request.getHeader("X-Hub-Signature"), bodyBytes);
         } else {
             if (payload.has("repository")) {
                 JSONObject repo = payload.getJSONObject("repository");
@@ -109,17 +110,17 @@ public class BitbucketPayloadProcessor {
                 String url = repo.getJSONObject("links").getJSONObject("html").getString("href");
                 String scm = repo.has("scm") ? repo.getString("scm") : "git";
 
-                probe.triggerMatchingJobs(user, url, scm, payload.toString());
+                return probe.triggerMatchingJobs(user, url, scm, payload.toString(), null, request.getHeader("X-Hub-Signature"), bodyBytes);
             } else if (payload.has("scm")) {
                 LOGGER.log(Level.FINER, "Received commit hook notification for hg: {0}", payload);
                 String user = getUser(payload, "owner");
                 String url = payload.getJSONObject("links").getJSONObject("html").getString("href");
                 String scm = payload.has("scm") ? payload.getString("scm") : "hg";
 
-                probe.triggerMatchingJobs(user, url, scm, payload.toString());
+                return probe.triggerMatchingJobs(user, url, scm, payload.toString(), null, request.getHeader("X-Hub-Signature"), bodyBytes);
             }
        }
-
+       return BitbucketWebhookResult.IGNORED;
     }
 
     private String getBranchName(JSONObject payload) {
@@ -183,7 +184,7 @@ public class BitbucketPayloadProcessor {
      *
      * @param payload JSON object
      */
-    private void processWebhookPayloadBitBucketServer(JSONObject payload) {
+    private BitbucketWebhookResult processWebhookPayloadBitBucketServer(JSONObject payload, HttpServletRequest request, byte[] bodyBytes) {
         JSONObject repo = payload.getJSONObject("repository");
         String user = getUser(payload, "actor");
         String url = "";
@@ -192,14 +193,15 @@ public class BitbucketPayloadProcessor {
                 URL pushHref = new URL(repo.getJSONObject("links").getJSONArray("self").getJSONObject(0).getString("href"));
                 url = pushHref.toString().replaceFirst("projects.*", repo.getString("fullName").toLowerCase());
                 String scm = repo.has("scmId") ? repo.getString("scmId") : "git";
-                probe.triggerMatchingJobs(user, url, scm, payload.toString());
+                return probe.triggerMatchingJobs(user, url, scm, payload.toString(), null, request.getHeader("X-Hub-Signature"), bodyBytes);
             } catch (MalformedURLException e) {
                 LOGGER.log(Level.WARNING, String.format("URL %s is malformed", url), e);
             }
         }
+        return BitbucketWebhookResult.IGNORED;
     }
 
-    private void processPostServicePayload(JSONObject payload) {
+    private BitbucketWebhookResult processPostServicePayload(JSONObject payload, HttpServletRequest request, byte[] bodyBytes) {
         JSONObject repo = payload.getJSONObject("repository");
         LOGGER.log(Level.FINER, "Received commit hook notification for {0}", repo);
 
@@ -207,7 +209,7 @@ public class BitbucketPayloadProcessor {
         String url = payload.getString("canon_url") + repo.getString("absolute_url");
         String scm = repo.getString("scm");
 
-        probe.triggerMatchingJobs(user, url, scm, payload.toString());
+        return probe.triggerMatchingJobs(user, url, scm, payload.toString(), null, request.getHeader("X-Hub-Signature"), bodyBytes);
     }
 
     private static final Logger LOGGER = Logger.getLogger(BitbucketPayloadProcessor.class.getName());

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketWebhookResult.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketWebhookResult.java
@@ -1,0 +1,8 @@
+package com.cloudbees.jenkins.plugins;
+
+enum BitbucketWebhookResult {
+    TRIGGERED,
+    NO_MATCH,
+    INVALID_SIGNATURE,
+    IGNORED
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketWebhookSignatureValidator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketWebhookSignatureValidator.java
@@ -1,0 +1,114 @@
+package com.cloudbees.jenkins.plugins;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+final class BitbucketWebhookSignatureValidator {
+
+    private BitbucketWebhookSignatureValidator() {
+    }
+
+    static boolean isValidSignature(@NonNull String header, @NonNull String secret, @NonNull byte[] payload) {
+        int separator = header.indexOf('=');
+        if (separator <= 0 || separator == header.length() - 1) {
+            LOGGER.log(Level.FINE, "Bitbucket webhook signature header is malformed");
+            return false;
+        }
+
+        String method = header.substring(0, separator).trim().toLowerCase(Locale.ROOT);
+        String signature = header.substring(separator + 1).trim();
+        if (signature.isEmpty()) {
+            LOGGER.log(Level.FINE, "Bitbucket webhook signature header does not contain a signature value");
+            return false;
+        }
+
+        String algorithm = getMacAlgorithm(method);
+        if (algorithm == null) {
+            LOGGER.log(Level.FINE, "Bitbucket webhook signature uses unsupported method: {0}", method);
+            return false;
+        }
+
+        LOGGER.log(Level.FINER, "Validating Bitbucket webhook signature using method: {0}", method);
+        byte[] expected = computeHmac(algorithm, secret, payload);
+        byte[] actual = decodeHex(signature);
+        if (actual == null) {
+            LOGGER.log(Level.FINE, "Bitbucket webhook signature is not valid hexadecimal");
+            return false;
+        }
+
+        boolean matches = MessageDigest.isEqual(expected, actual);
+        if (!matches) {
+            LOGGER.log(Level.FINE, "Bitbucket webhook signature did not match the computed HMAC");
+        } else {
+            LOGGER.log(Level.FINE, "Bitbucket webhook HMAC secret validated successfully");
+        }
+        return matches;
+    }
+
+    static String createSignatureHeader(@NonNull String method, @NonNull String secret, @NonNull String payload) {
+        String normalizedMethod = method.trim().toLowerCase(Locale.ROOT);
+        String algorithm = getMacAlgorithm(normalizedMethod);
+        if (algorithm == null) {
+            throw new IllegalArgumentException("Unsupported signature method: " + method);
+        }
+
+        byte[] digest = computeHmac(algorithm, secret, payload.getBytes(StandardCharsets.UTF_8));
+        return normalizedMethod + "=" + toHex(digest);
+    }
+
+    private static String getMacAlgorithm(String method) {
+        return switch (method) {
+            case "sha1" -> "HmacSHA1";
+            case "sha256" -> "HmacSHA256";
+            case "sha384" -> "HmacSHA384";
+            case "sha512" -> "HmacSHA512";
+            default -> null;
+        };
+    }
+
+    private static byte[] computeHmac(String algorithm, String secret, byte[] payload) {
+        try {
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), algorithm));
+            return mac.doFinal(payload);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Could not compute webhook signature", e);
+        }
+    }
+
+    private static byte[] decodeHex(String value) {
+        if ((value.length() & 1) != 0) {
+            return null;
+        }
+
+        byte[] result = new byte[value.length() / 2];
+        for (int i = 0; i < value.length(); i += 2) {
+            int high = Character.digit(value.charAt(i), 16);
+            int low = Character.digit(value.charAt(i + 1), 16);
+            if (high < 0 || low < 0) {
+                return null;
+            }
+            result[i / 2] = (byte) ((high << 4) + low);
+        }
+        return result;
+    }
+
+    private static String toHex(byte[] value) {
+        StringBuilder builder = new StringBuilder(value.length * 2);
+        for (byte b : value) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketWebhookSignatureValidator.class.getName());
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/BitBucketTrigger/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/BitBucketTrigger/config.jelly
@@ -17,4 +17,7 @@
     <f:entry title="Build on branch created" field="buildOnCreatedBranch">
         <f:checkbox />
     </f:entry>
+    <f:entry title="Web hook secret (hmac)" field="webhookSecret">
+        <f:password />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/BitBucketTrigger/help-webhookSecret.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/BitBucketTrigger/help-webhookSecret.html
@@ -1,0 +1,2 @@
+Optional HMAC secret used to validate Bitbucket webhook requests for this job.
+When set, Jenkins expects a matching <code>X-Hub-Signature</code> for webhook payloads that match this job.

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
@@ -1,5 +1,8 @@
 package com.cloudbees.jenkins.plugins;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +35,7 @@ class BitbucketPayloadProcessorTest {
     @BeforeEach
     void setUp() {
         payloadProcessor = new BitbucketPayloadProcessor(probe);
+        when(probe.triggerMatchingJobs(any(), any(), any(), any(), any(), any(), any())).thenReturn(BitbucketWebhookResult.TRIGGERED);
     }
 
     @Test
@@ -59,13 +63,13 @@ class BitbucketPayloadProcessorTest {
                 .element("html", new JSONObject()
                     .element("href", url)));
 
-        payloadProcessor.processPayload(payload, request);
+        payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs(user, url, "git", payload.toString());
+        verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
 
-        payloadProcessor.processPayload(hgLoad, request);
+        payloadProcessor.processPayload(hgLoad, request, hgLoad.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs(user, url, "hg", hgLoad.toString());
+        verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("hg"), eq(hgLoad.toString()), isNull(), isNull(), any(byte[].class));
     }
 
     @Test
@@ -89,9 +93,9 @@ class BitbucketPayloadProcessorTest {
                                     .element(href)))
                         .element("fullName",  "CE/test_repo"));
 
-        payloadProcessor.processPayload(payload, request);
+        payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs(user, url, "git", payload.toString());
+        verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
     }
 
     @Test
@@ -106,9 +110,9 @@ class BitbucketPayloadProcessorTest {
                 .element("scm", "git")
                 .element("absolute_url", "/old_user/old_repo"));
 
-        payloadProcessor.processPayload(payload, request);
+        payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs("old_user", "https://staging.bitbucket.org/old_user/old_repo", "git", payload.toString());
+        verify(probe).triggerMatchingJobs(eq("old_user"), eq("https://staging.bitbucket.org/old_user/old_repo"), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
     }
 
 
@@ -119,9 +123,9 @@ class BitbucketPayloadProcessorTest {
 
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("bitbucket_pr_merge_payload.json")) {
         	JSONObject payload = JSONObject.fromObject(IOUtils.toString(input, StandardCharsets.UTF_8));
-            payloadProcessor.processPayload(payload, request);
+            payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-            verify(probe).triggerMatchingJobs(user, url, "git", payload.toString());
+            verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
         }
 
     }
@@ -133,9 +137,9 @@ class BitbucketPayloadProcessorTest {
 
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("bitbucket_pr_merge_payload.json")) {
         	JSONObject payload = JSONObject.fromObject(IOUtils.toString(input, StandardCharsets.UTF_8));
-            payloadProcessor.processPayload(payload, request);
+            payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-            verify(probe).triggerMatchingJobs(user, url, "git", payload.toString());
+            verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
         }
     }
 
@@ -165,12 +169,12 @@ class BitbucketPayloadProcessorTest {
                         .element("html", new JSONObject()
                                 .element("href", url)));
 
-        payloadProcessor.processPayload(payload, request);
+        payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs(user, url, "git", payload.toString());
+        verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("git"), eq(payload.toString()), isNull(), isNull(), any(byte[].class));
 
-        payloadProcessor.processPayload(hgLoad, request);
+        payloadProcessor.processPayload(hgLoad, request, hgLoad.toString().getBytes(StandardCharsets.UTF_8));
 
-        verify(probe).triggerMatchingJobs(user, url, "hg", hgLoad.toString());
+        verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("hg"), eq(hgLoad.toString()), isNull(), isNull(), any(byte[].class));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketWebhookSignatureTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketWebhookSignatureTest.java
@@ -1,0 +1,122 @@
+package com.cloudbees.jenkins.plugins;
+
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.GitSCM;
+import hudson.util.Secret;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WithJenkins
+class BitbucketWebhookSignatureTest {
+
+    private static final String PAYLOAD = "{\"push\":{\"changes\":[]},\"repository\":{\"links\":{\"html\":{\"href\":\"https://bitbucket.org/test/repo\"}}},\"actor\":{\"nickname\":\"test-user\"}}";
+
+    @Test
+    void shouldAcceptUnsignedWebhookWhenSecretNotConfigured(JenkinsRule jenkins) throws Exception {
+        createJob(jenkins, null);
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            WebResponse response = submitWebhook(webClient, PAYLOAD, null);
+
+            assertEquals(200, response.getStatusCode());
+        }
+    }
+
+    @Test
+    void shouldRejectSignedWebhookWhenJobHasNoSecretConfigured(JenkinsRule jenkins) throws Exception {
+        createJob(jenkins, null);
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            WebResponse response = submitWebhook(
+                    webClient,
+                    PAYLOAD,
+                    BitbucketWebhookSignatureValidator.createSignatureHeader("sha256", "super-secret", PAYLOAD)
+            );
+
+            assertEquals(403, response.getStatusCode());
+        }
+    }
+
+    @Test
+    void shouldAcceptSignedWebhookWhenSecretConfigured(JenkinsRule jenkins) throws Exception {
+        createJob(jenkins, "It's a Secret to Everybody");
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            WebResponse response = submitWebhook(
+                    webClient,
+                    PAYLOAD,
+                    BitbucketWebhookSignatureValidator.createSignatureHeader("sha256", "It's a Secret to Everybody", PAYLOAD)
+            );
+
+            assertEquals(200, response.getStatusCode());
+        }
+    }
+
+    @Test
+    void shouldRejectMissingSignatureWhenSecretConfigured(JenkinsRule jenkins) throws Exception {
+        createJob(jenkins, "super-secret");
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            WebResponse response = submitWebhook(webClient, PAYLOAD, null);
+
+            assertEquals(403, response.getStatusCode());
+        }
+    }
+
+    @Test
+    void shouldRejectInvalidSignatureWhenSecretConfigured(JenkinsRule jenkins) throws Exception {
+        createJob(jenkins, "super-secret");
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            WebResponse response = submitWebhook(webClient, PAYLOAD, "sha256=deadbeef");
+
+            assertEquals(403, response.getStatusCode());
+        }
+    }
+
+    @Test
+    void shouldRejectWebhookWhenNoMatchingJobExists(JenkinsRule jenkins) throws Exception {
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            WebResponse response = submitWebhook(webClient, PAYLOAD, null);
+
+            assertEquals(200, response.getStatusCode());
+        }
+    }
+
+    private WebResponse submitWebhook(JenkinsRule.WebClient webClient, String payload, String signature) throws Exception {
+        WebRequest request = new WebRequest(new URL(webClient.getContextPath() + "bitbucket-hook/"), HttpMethod.POST);
+        request.setAdditionalHeader("Content-Type", "application/json");
+        request.setAdditionalHeader("X-Event-Key", "repo:push");
+        request.setAdditionalHeader("User-Agent", "Bitbucket-Webhooks/2.0");
+        if (signature != null) {
+            request.setAdditionalHeader("X-Hub-Signature", signature);
+        }
+        request.setRequestBody(payload);
+        return webClient.getPage(request).getWebResponse();
+    }
+
+    private void createJob(JenkinsRule jenkins, String secret) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("bitbucket-job");
+        project.setScm(new GitSCM("https://bitbucket.org/test/repo"));
+
+        BitBucketTrigger trigger = new BitBucketTrigger();
+        if (secret != null) {
+            trigger.setWebhookSecret(Secret.fromString(secret));
+        }
+        project.addTrigger(trigger);
+        trigger.start(project, true);
+        project.save();
+    }
+}


### PR DESCRIPTION
Add support for validating Bitbucket webhook HMAC secrets per job.

This change adds a new trigger field, `Web hook secret (hmac)`, to jobs using `Build when a change is pushed to BitBucket`. When configured, incoming webhook requests must include a valid `X-Hub-Signature` for that matching job. If a signed webhook targets a job without a configured secret, the request is rejected. If no job matches the webhook payload, the plugin now logs a warning but preserves the existing `200` response behavior.

Related issue:
- [JENKINS-73111](https://issues.jenkins.io/browse/JENKINS-73111)

Related pull request:
- [#156](https://github.com/jenkinsci/bitbucket-plugin/pull/156)

### Testing done

Automated tests:
- Ran:
  `/opt/homebrew/opt/sdkman-cli/libexec/candidates/maven/current/bin/mvn -Dtest=CrumbExclusionTest,BitbucketWebhookSignatureTest,BitbucketPayloadProcessorTest,BitbucketTriggerTest test`
- Result:
  `BUILD SUCCESS`
- Total:
  `Tests run: 15, Failures: 0, Errors: 0, Skipped: 0`

Added/updated test coverage includes:
- unsigned webhook accepted when matching job has no secret
- signed webhook rejected when matching job has no secret
- signed webhook accepted when matching job secret is configured correctly
- missing signature rejected when matching job secret is configured
- invalid signature rejected when matching job secret is configured
- no matching job logs warning while preserving successful HTTP response behavior

Manual testing:
- Ran the plugin locally with `mvn hpi:run`
- Created a freestyle job with `Build when a change is pushed to BitBucket`
- Verified the new `Web hook secret (hmac)` field appears after `Build on branch created`
- Sent webhook requests to `/bitbucket-hook/` with and without `X-Hub-Signature`
- Verified valid signed requests were accepted for matching jobs with the configured secret
- Verified signed requests were rejected when the matching job had no configured secret
- Verified unmatched webhook payloads log a warning without changing the legacy success response behavior

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
