### PR TITLE
Jenkins 33989 - Adds Bitbucket sidebar links for jobs managed by this plugin.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketExternalLink.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketExternalLink.java
@@ -1,0 +1,50 @@
+package com.cloudbees.jenkins.plugins;
+
+import hudson.model.Action;
+import org.jenkins.ui.icon.IconSpec;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+/**
+ * Sidebar link to an external Bitbucket page.
+ */
+public class BitbucketExternalLink implements Action, IconSpec {
+
+    private static final String BITBUCKET_ICON_CLASS_NAME = "symbol-logo-bitbucket plugin-ionicons-api";
+    private static final String FALLBACK_ICON_CLASS_NAME = "symbol-link-outline plugin-ionicons-api";
+
+    private final String displayName;
+    private final String url;
+
+    public BitbucketExternalLink(String displayName, String url) {
+        this.displayName = displayName;
+        this.url = url;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getIconClassName() {
+        return hasSymbol("logo-bitbucket") ? BITBUCKET_ICON_CLASS_NAME : FALLBACK_ICON_CLASS_NAME;
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return url;
+    }
+
+    private boolean hasSymbol(String name) {
+        return BitbucketExternalLink.class.getClassLoader()
+                .getResource("images/symbols/" + name + ".svg") != null;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobLinkActionFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobLinkActionFactory.java
@@ -1,0 +1,95 @@
+package com.cloudbees.jenkins.plugins;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.TopLevelItem;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.SCM;
+import jenkins.model.TransientActionFactory;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+@Extension
+public class BitbucketJobLinkActionFactory extends TransientActionFactory<Job> {
+
+    @FunctionalInterface
+    interface SCMHeadByItemProvider {
+        SCMHead findHead(Item item);
+    }
+
+    @FunctionalInterface
+    interface SCMSourceByItemProvider {
+        SCMSource findSource(Item item);
+    }
+
+    private final BitbucketLinkUtils linkUtils;
+    private final SCMHeadByItemProvider headProvider;
+    private final SCMSourceByItemProvider sourceProvider;
+
+    public BitbucketJobLinkActionFactory() {
+        this(new BitbucketLinkUtils(), SCMHead.HeadByItem::findHead, SCMSource.SourceByItem::findSource);
+    }
+
+    BitbucketJobLinkActionFactory(BitbucketLinkUtils linkUtils,
+                                  SCMHeadByItemProvider headProvider,
+                                  SCMSourceByItemProvider sourceProvider) {
+        this.linkUtils = linkUtils;
+        this.headProvider = headProvider;
+        this.sourceProvider = sourceProvider;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Job target) {
+        if (target instanceof WorkflowJob) {
+            WorkflowJob workflowJob = (WorkflowJob) target;
+            Optional<BitbucketExternalLink> branchLink = createBranchLink(workflowJob);
+            if (branchLink.isPresent()) {
+                return Collections.singletonList(branchLink.get());
+            }
+            if (workflowJob.getDefinition() instanceof CpsScmFlowDefinition) {
+                SCM scm = ((CpsScmFlowDefinition) workflowJob.getDefinition()).getScm();
+                return linkUtils.createRepoLink(scm)
+                        .map(Collections::singletonList)
+                        .orElse(Collections.emptyList());
+            }
+        }
+
+        if (target instanceof TopLevelItem && target instanceof hudson.model.Project) {
+            SCM scm = ((hudson.model.Project<?, ?>) target).getScm();
+            if (scm instanceof GitSCM) {
+                return linkUtils.createRepoLink(scm)
+                        .map(Collections::singletonList)
+                        .orElse(Collections.emptyList());
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private Optional<BitbucketExternalLink> createBranchLink(WorkflowJob workflowJob) {
+        if (!(workflowJob.getParent() instanceof WorkflowMultiBranchProject)) {
+            return Optional.empty();
+        }
+        SCMSource source = sourceProvider.findSource(workflowJob);
+        SCMHead head = headProvider.findHead(workflowJob);
+        if (source == null || head == null) {
+            return Optional.empty();
+        }
+        return linkUtils.createBranchLink(source, head.getName());
+    }
+
+    @Override
+    public Class<Job> type() {
+        return Job.class;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobLinkActionFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobLinkActionFactory.java
@@ -11,6 +11,8 @@ import jenkins.model.TransientActionFactory;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
@@ -85,7 +87,14 @@ public class BitbucketJobLinkActionFactory extends TransientActionFactory<Job> {
         if (source == null || head == null) {
             return Optional.empty();
         }
+        if (!supportsBranchLink(head)) {
+            return Optional.empty();
+        }
         return linkUtils.createBranchLink(source, head.getName());
+    }
+
+    static boolean supportsBranchLink(SCMHead head) {
+        return !(head instanceof ChangeRequestSCMHead) && !(head instanceof TagSCMHead);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
@@ -89,8 +89,9 @@ final class BitbucketLinkUtils {
                 return Optional.of(BitbucketRemote.cloud(httpsBaseUrl(host), segments[0], stripGitSuffix(segments[1])));
             }
 
-            boolean allowSimpleServerPath = uri.getScheme() == null || !"http".equalsIgnoreCase(uri.getScheme())
-                    && !"https".equalsIgnoreCase(uri.getScheme());
+            boolean allowSimpleServerPath = (uri.getScheme() == null || !"http".equalsIgnoreCase(uri.getScheme())
+                    && !"https".equalsIgnoreCase(uri.getScheme()))
+                    && looksLikeBitbucketServerHost(host);
             ParsedServerPath parsedServerPath = ParsedServerPath.from(path, allowSimpleServerPath);
             if (parsedServerPath == null) {
                 return Optional.empty();
@@ -130,6 +131,11 @@ final class BitbucketLinkUtils {
 
     private static boolean isBitbucketCloudHost(String host) {
         return "bitbucket.org".equalsIgnoreCase(host);
+    }
+
+    private static boolean looksLikeBitbucketServerHost(String host) {
+        String normalizedHost = host.toLowerCase(Locale.ENGLISH);
+        return normalizedHost.contains("bitbucket") || normalizedHost.contains("stash");
     }
 
     private static String httpsBaseUrl(String host) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
@@ -98,7 +98,7 @@ final class BitbucketLinkUtils {
             }
             return Optional.of(BitbucketRemote.server(
                     httpsBaseUrl(host, parsedServerPath.contextPath()),
-                    parsedServerPath.projectKey(),
+                    parsedServerPath.parsedProjectKey(),
                     parsedServerPath.repositorySlug()
             ));
         } catch (Exception ignored) {
@@ -224,7 +224,7 @@ final class BitbucketLinkUtils {
         SERVER
     }
 
-    private record ParsedServerPath(String contextPath, String projectKey, String repositorySlug) {
+    private record ParsedServerPath(String contextPath, String parsedProjectKey, String repositorySlug) {
         static ParsedServerPath from(String rawPath, boolean allowSimplePath) {
             String[] segments = rawPath.split("/");
             if (segments.length >= 3) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
@@ -1,0 +1,249 @@
+package com.cloudbees.jenkins.plugins;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.SCM;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMSource;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+final class BitbucketLinkUtils {
+
+    static final String REPOSITORY_LINK_NAME = "Browse Repository";
+    static final String BRANCH_LINK_NAME = "View Branch";
+
+    Optional<BitbucketExternalLink> createRepoLink(SCMSource source) {
+        return resolve(source)
+                .map(remote -> new BitbucketExternalLink(REPOSITORY_LINK_NAME, remote.toRepositoryUrl()));
+    }
+
+    Optional<BitbucketExternalLink> createBranchLink(SCMSource source, String branch) {
+        if (branch == null || branch.isBlank()) {
+            return Optional.empty();
+        }
+        return resolve(source)
+                .map(remote -> new BitbucketExternalLink(BRANCH_LINK_NAME, remote.toBranchUrl(branch)));
+    }
+
+    Optional<BitbucketExternalLink> createRepoLink(SCM scm) {
+        return resolve(scm)
+                .map(remote -> new BitbucketExternalLink(REPOSITORY_LINK_NAME, remote.toRepositoryUrl()));
+    }
+
+    Optional<BitbucketRemote> resolve(SCMSource source) {
+        if (source instanceof GitSCMSource) {
+            return parseRemote(((GitSCMSource) source).getRemote());
+        }
+        if (source instanceof BitbucketSCMSource) {
+            BitbucketSCMSource bitbucketSource = (BitbucketSCMSource) source;
+            return fromCoordinates(
+                    bitbucketSource.getServerUrl(),
+                    bitbucketSource.getRepoOwner(),
+                    bitbucketSource.getRepository()
+            );
+        }
+        return Optional.empty();
+    }
+
+    Optional<BitbucketRemote> resolve(SCM scm) {
+        if (!(scm instanceof GitSCM)) {
+            return Optional.empty();
+        }
+        List<RemoteConfig> repositories = ((GitSCM) scm).getRepositories();
+        for (RemoteConfig repository : repositories) {
+            for (URIish uri : repository.getURIs()) {
+                Optional<BitbucketRemote> remote = parseRemote(uri.toString());
+                if (remote.isPresent()) {
+                    return remote;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    Optional<BitbucketRemote> parseRemote(@CheckForNull String remote) {
+        if (remote == null || remote.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            URIish uri = new URIish(remote);
+            String host = uri.getHost();
+            String path = stripSlashes(uri.getPath());
+            if (host == null || host.isBlank() || path == null || path.isBlank()) {
+                return Optional.empty();
+            }
+            if (isBitbucketCloudHost(host)) {
+                String[] segments = path.split("/");
+                if (segments.length < 2) {
+                    return Optional.empty();
+                }
+                return Optional.of(BitbucketRemote.cloud(httpsBaseUrl(host), segments[0], stripGitSuffix(segments[1])));
+            }
+
+            boolean allowSimpleServerPath = uri.getScheme() == null || !"http".equalsIgnoreCase(uri.getScheme())
+                    && !"https".equalsIgnoreCase(uri.getScheme());
+            ParsedServerPath parsedServerPath = ParsedServerPath.from(path, allowSimpleServerPath);
+            if (parsedServerPath == null) {
+                return Optional.empty();
+            }
+            return Optional.of(BitbucketRemote.server(
+                    httpsBaseUrl(host, parsedServerPath.contextPath()),
+                    parsedServerPath.projectKey(),
+                    parsedServerPath.repositorySlug()
+            ));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<BitbucketRemote> fromCoordinates(@CheckForNull String serverUrl,
+                                                      @CheckForNull String ownerOrProject,
+                                                      @CheckForNull String repository) {
+        if (serverUrl == null || serverUrl.isBlank() || ownerOrProject == null || ownerOrProject.isBlank()
+                || repository == null || repository.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedServerUrl = trimTrailingSlash(serverUrl);
+        try {
+            URIish uri = new URIish(normalizedServerUrl);
+            String host = uri.getHost();
+            if (host == null || host.isBlank()) {
+                return Optional.empty();
+            }
+            if (isBitbucketCloudHost(host)) {
+                return Optional.of(BitbucketRemote.cloud(normalizedServerUrl, ownerOrProject, stripGitSuffix(repository)));
+            }
+            return Optional.of(BitbucketRemote.server(normalizedServerUrl, ownerOrProject, stripGitSuffix(repository)));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isBitbucketCloudHost(String host) {
+        return "bitbucket.org".equalsIgnoreCase(host);
+    }
+
+    private static String httpsBaseUrl(String host) {
+        return "https://" + host;
+    }
+
+    private static String httpsBaseUrl(String host, String contextPath) {
+        if (contextPath.isBlank()) {
+            return httpsBaseUrl(host);
+        }
+        return httpsBaseUrl(host) + "/" + contextPath;
+    }
+
+    private static String stripGitSuffix(String value) {
+        return value.endsWith(".git") ? value.substring(0, value.length() - 4) : value;
+    }
+
+    private static String stripSlashes(@CheckForNull String value) {
+        if (value == null) {
+            return null;
+        }
+        String stripped = value;
+        while (stripped.startsWith("/")) {
+            stripped = stripped.substring(1);
+        }
+        while (stripped.endsWith("/")) {
+            stripped = stripped.substring(0, stripped.length() - 1);
+        }
+        return stripped;
+    }
+
+    private static String trimTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static String encodeQuery(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String encodePath(String value) {
+        return encodeQuery(value).replace("+", "%20");
+    }
+
+    static final class BitbucketRemote {
+        private final Kind kind;
+        private final String baseUrl;
+        private final String ownerOrProject;
+        private final String repositorySlug;
+
+        private BitbucketRemote(Kind kind, String baseUrl, String ownerOrProject, String repositorySlug) {
+            this.kind = kind;
+            this.baseUrl = trimTrailingSlash(baseUrl);
+            this.ownerOrProject = ownerOrProject;
+            this.repositorySlug = repositorySlug;
+        }
+
+        static BitbucketRemote cloud(String baseUrl, String workspace, String repositorySlug) {
+            return new BitbucketRemote(Kind.CLOUD, baseUrl, workspace, repositorySlug);
+        }
+
+        static BitbucketRemote server(String baseUrl, String projectKey, String repositorySlug) {
+            return new BitbucketRemote(Kind.SERVER, baseUrl, projectKey, repositorySlug);
+        }
+
+        String toRepositoryUrl() {
+            if (kind == Kind.CLOUD) {
+                return baseUrl + "/" + ownerOrProject + "/" + repositorySlug;
+            }
+            return baseUrl + "/projects/" + ownerOrProject + "/repos/" + repositorySlug;
+        }
+
+        String toBranchUrl(String branch) {
+            if (kind == Kind.CLOUD) {
+                return toRepositoryUrl() + "/branch/" + encodePath(branch);
+            }
+            return toRepositoryUrl() + "/compare/commits?sourceBranch=" + encodeQuery("refs/heads/" + branch);
+        }
+    }
+
+    private enum Kind {
+        CLOUD,
+        SERVER
+    }
+
+    private record ParsedServerPath(String contextPath, String projectKey, String repositorySlug) {
+        static ParsedServerPath from(String rawPath, boolean allowSimplePath) {
+            String[] segments = rawPath.split("/");
+            if (segments.length >= 3) {
+                for (int i = 0; i < segments.length; i++) {
+                    if ("scm".equalsIgnoreCase(segments[i]) && i + 2 < segments.length) {
+                        return new ParsedServerPath(
+                                String.join("/", java.util.Arrays.copyOfRange(segments, 0, i)),
+                                segments[i + 1],
+                                stripGitSuffix(segments[i + 2])
+                        );
+                    }
+                    if ("projects".equalsIgnoreCase(segments[i]) && i + 3 < segments.length
+                            && "repos".equalsIgnoreCase(segments[i + 2])) {
+                        return new ParsedServerPath(
+                                String.join("/", java.util.Arrays.copyOfRange(segments, 0, i)),
+                                segments[i + 1],
+                                stripGitSuffix(segments[i + 3])
+                        );
+                    }
+                }
+            }
+            if (allowSimplePath && segments.length == 2 && !"scm".equalsIgnoreCase(segments[0])) {
+                return new ParsedServerPath("", segments[0].toUpperCase(Locale.ENGLISH), stripGitSuffix(segments[1]));
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketMultibranchLinkActionFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketMultibranchLinkActionFactory.java
@@ -1,0 +1,39 @@
+package com.cloudbees.jenkins.plugins;
+
+import hudson.Extension;
+import hudson.model.Action;
+import jenkins.model.TransientActionFactory;
+import jenkins.scm.api.SCMSource;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Extension
+public class BitbucketMultibranchLinkActionFactory extends TransientActionFactory<WorkflowMultiBranchProject> {
+
+    private final BitbucketLinkUtils linkUtils;
+
+    public BitbucketMultibranchLinkActionFactory() {
+        this(new BitbucketLinkUtils());
+    }
+
+    BitbucketMultibranchLinkActionFactory(BitbucketLinkUtils linkUtils) {
+        this.linkUtils = linkUtils;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(WorkflowMultiBranchProject target) {
+        for (SCMSource source : target.getSCMSources()) {
+            if (linkUtils.createRepoLink(source).isPresent()) {
+                return Collections.singletonList(linkUtils.createRepoLink(source).get());
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Class<WorkflowMultiBranchProject> type() {
+        return WorkflowMultiBranchProject.class;
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
@@ -2,6 +2,9 @@ package com.cloudbees.jenkins.plugins;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -12,6 +15,33 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @WithJenkins
 class BitbucketLinkActionFactoryTest {
+
+    private static class PullRequestHead extends SCMHead implements ChangeRequestSCMHead {
+        PullRequestHead(String name) {
+            super(name);
+        }
+
+        @Override
+        public String getId() {
+            return "1";
+        }
+
+        @Override
+        public SCMHead getTarget() {
+            return new SCMHead("main") {};
+        }
+    }
+
+    private static class TagHead extends SCMHead implements TagSCMHead {
+        TagHead(String name) {
+            super(name);
+        }
+
+        @Override
+        public long getTimestamp() {
+            return 0;
+        }
+    }
 
     @Test
     void multibranchProjectsGetBrowseRepositoryLink(JenkinsRule j) throws Exception {
@@ -25,5 +55,12 @@ class BitbucketLinkActionFactoryTest {
         assertNotNull(action);
         assertEquals(BitbucketLinkUtils.REPOSITORY_LINK_NAME, action.getDisplayName());
         assertEquals("https://stash.example.com/bitbucket/projects/PRJ/repos/repo", action.getUrlName());
+    }
+
+    @Test
+    void branchLinksAreSuppressedForPullRequestsAndTags() {
+        assertEquals(false, BitbucketJobLinkActionFactory.supportsBranchLink(new PullRequestHead("PR-1")));
+        assertEquals(false, BitbucketJobLinkActionFactory.supportsBranchLink(new TagHead("v1.0.0")));
+        assertEquals(true, BitbucketJobLinkActionFactory.supportsBranchLink(new SCMHead("main") {}));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
@@ -1,0 +1,29 @@
+package com.cloudbees.jenkins.plugins;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import jenkins.branch.BranchSource;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@WithJenkins
+class BitbucketLinkActionFactoryTest {
+
+    @Test
+    void multibranchProjectsGetBrowseRepositoryLink(JenkinsRule j) throws Exception {
+        WorkflowMultiBranchProject project = j.jenkins.createProject(WorkflowMultiBranchProject.class, "mbp");
+        BitbucketSCMSource source = new BitbucketSCMSource("PRJ", "repo");
+        source.setServerUrl("https://stash.example.com/bitbucket");
+        project.getSourcesList().add(new BranchSource(source));
+
+        BitbucketExternalLink action = project.getAction(BitbucketExternalLink.class);
+
+        assertNotNull(action);
+        assertEquals(BitbucketLinkUtils.REPOSITORY_LINK_NAME, action.getDisplayName());
+        assertEquals("https://stash.example.com/bitbucket/projects/PRJ/repos/repo", action.getUrlName());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
@@ -1,0 +1,91 @@
+package com.cloudbees.jenkins.plugins;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BitbucketLinkUtilsTest {
+
+    private final BitbucketLinkUtils linkUtils = new BitbucketLinkUtils();
+
+    @Test
+    void parsesBitbucketServerHttpRemote() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("https://stash.example.com/bitbucket/scm/PRJ/repo.git")
+                .orElseThrow();
+
+        assertEquals("https://stash.example.com/bitbucket/projects/PRJ/repos/repo", remote.toRepositoryUrl());
+        assertEquals(
+                "https://stash.example.com/bitbucket/projects/PRJ/repos/repo/compare/commits?sourceBranch=refs%2Fheads%2Ffeature%2Ftest",
+                remote.toBranchUrl("feature/test")
+        );
+    }
+
+    @Test
+    void parsesBitbucketServerSshRemote() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("ssh://git@stash.example.com:7999/bitbucket/scm/PRJ/repo.git")
+                .orElseThrow();
+
+        assertEquals("https://stash.example.com/bitbucket/projects/PRJ/repos/repo", remote.toRepositoryUrl());
+    }
+
+    @Test
+    void parsesBitbucketCloudRemote() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("git@bitbucket.org:workspace/repo.git")
+                .orElseThrow();
+
+        assertEquals("https://bitbucket.org/workspace/repo", remote.toRepositoryUrl());
+        assertEquals("https://bitbucket.org/workspace/repo/branch/feature%2Ftest", remote.toBranchUrl("feature/test"));
+    }
+
+    @Test
+    void parsesBitbucketCloudSshRemoteFromIssueExample() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("git@bitbucket.org:tzachs/test.git")
+                .orElseThrow();
+
+        assertEquals("https://bitbucket.org/tzachs/test", remote.toRepositoryUrl());
+        assertEquals("https://bitbucket.org/tzachs/test/branch/master", remote.toBranchUrl("master"));
+    }
+
+    @Test
+    void parsesBitbucketServerScpStyleSshRemote() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("git@stash.example.com:PRJ/repo.git")
+                .orElseThrow();
+
+        assertEquals("https://stash.example.com/projects/PRJ/repos/repo", remote.toRepositoryUrl());
+        assertEquals(
+                "https://stash.example.com/projects/PRJ/repos/repo/compare/commits?sourceBranch=refs%2Fheads%2Ffeature%2Ftest",
+                remote.toBranchUrl("feature/test")
+        );
+    }
+
+    @Test
+    void createsLinksFromBitbucketBranchSourceCoordinates() {
+        BitbucketSCMSource source = new BitbucketSCMSource("PRJ", "repo");
+        source.setServerUrl("https://stash.example.com/bitbucket");
+
+        BitbucketExternalLink repoLink = linkUtils.createRepoLink(source).orElseThrow();
+        BitbucketExternalLink branchLink = linkUtils.createBranchLink(source, "feature/test").orElseThrow();
+
+        assertEquals(BitbucketLinkUtils.REPOSITORY_LINK_NAME, repoLink.getDisplayName());
+        assertEquals("https://stash.example.com/bitbucket/projects/PRJ/repos/repo", repoLink.getUrlName());
+        assertEquals(BitbucketLinkUtils.BRANCH_LINK_NAME, branchLink.getDisplayName());
+        assertEquals(
+                "https://stash.example.com/bitbucket/projects/PRJ/repos/repo/compare/commits?sourceBranch=refs%2Fheads%2Ffeature%2Ftest",
+                branchLink.getUrlName()
+        );
+    }
+
+    @Test
+    void ignoresNonBitbucketRemote() {
+        assertTrue(linkUtils.parseRemote("/tmp/local-repo").isEmpty());
+        assertFalse(linkUtils.parseRemote("https://github.com/jenkinsci/bitbucket-plugin.git").isPresent());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
@@ -67,6 +67,15 @@ class BitbucketLinkUtilsTest {
     }
 
     @Test
+    void parsesBitbucketServerScpStyleSshRemoteForBitbucketHost() {
+        BitbucketLinkUtils.BitbucketRemote remote = linkUtils
+                .parseRemote("git@bitbucket.example.com:PRJ/repo.git")
+                .orElseThrow();
+
+        assertEquals("https://bitbucket.example.com/projects/PRJ/repos/repo", remote.toRepositoryUrl());
+    }
+
+    @Test
     void createsLinksFromBitbucketBranchSourceCoordinates() {
         BitbucketSCMSource source = new BitbucketSCMSource("PRJ", "repo");
         source.setServerUrl("https://stash.example.com/bitbucket");
@@ -87,5 +96,7 @@ class BitbucketLinkUtilsTest {
     void ignoresNonBitbucketRemote() {
         assertTrue(linkUtils.parseRemote("/tmp/local-repo").isEmpty());
         assertFalse(linkUtils.parseRemote("https://github.com/jenkinsci/bitbucket-plugin.git").isPresent());
+        assertFalse(linkUtils.parseRemote("git@github.com:jenkinsci/bitbucket-plugin.git").isPresent());
+        assertFalse(linkUtils.parseRemote("git@gitlab.com:group/repo.git").isPresent());
     }
 }


### PR DESCRIPTION
Adds Bitbucket sidebar links for jobs managed by this plugin.

This change introduces transient sidebar actions that infer Bitbucket repository URLs from the configured SCM remote and show:
- `Browse Repository` on multibranch projects
- `View Branch` on multibranch branch jobs
- `Browse Repository` on freestyle jobs and Pipeline-from-SCM jobs when the remote can be recognized as Bitbucket

The implementation is intentionally conservative:
- Bitbucket Cloud remotes such as `https://bitbucket.org/...` and `git@bitbucket.org:...` are supported
- Bitbucket Server/Data Center remotes such as `.../scm/PROJECT/repo.git` and SCP-style SSH remotes on hosts containing `bitbucket` or `stash` are supported
- generic non-Bitbucket SSH remotes like `git@github.com:...` are ignored
- PR and tag heads do not get a `View Branch` link to avoid generating incorrect URLs

Fixes [JENKINS-33989](https://issues.jenkins.io/browse/JENKINS-33989).

### Testing done

Automated tests:
- Ran `mvn -q -Dtest=BitbucketLinkUtilsTest,BitbucketLinkActionFactoryTest test`
- Added coverage for:
  - Bitbucket Server HTTP remote parsing
  - Bitbucket Server SSH remote parsing
  - Bitbucket Cloud SSH remote parsing including `git@bitbucket.org:tzachs/test.git`
  - rejection of non-Bitbucket remotes such as GitHub and GitLab SCP-style SSH remotes
  - multibranch project sidebar action creation
  - suppression of branch links for PR/tag heads

Manual testing:
- Built the plugin and loaded it in a local Jenkins Docker image
- Verified that a multibranch project shows `Browse Repository`
- Verified that recognized Bitbucket remotes render the Bitbucket sidebar icon, with fallback to the generic link icon if the Bitbucket symbol is unavailable

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Related pull request:
- [#160](https://github.com/jenkinsci/bitbucket-plugin/pull/160)
