### PR TITLE
JENKINS-69670 Fix branch-created pushes with commits

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTriggerRunnable.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitBucketTriggerRunnable.java
@@ -32,6 +32,33 @@ public class BitBucketTriggerRunnable implements Runnable {
         this.buildOnCreatedBranch = buildOnCreatedBranch;
     }
 
+    boolean shouldTriggerBuild(boolean pollingFoundChanges, PrintStream logger) {
+        if (this.branchName == null || this.branchName.isEmpty()) {
+            if (pollingFoundChanges) {
+                logger.println("Changes found");
+            } else {
+                logger.println("No changes");
+            }
+            return pollingFoundChanges;
+        }
+
+        if (pollingFoundChanges) {
+            logger.println("Changes found");
+            logger.println("Branch [" + this.branchName + "] was created");
+            return true;
+        }
+
+        if (this.buildOnCreatedBranch) {
+            logger.println("No changes");
+            logger.println("Branch [" + this.branchName + "] was created");
+            return true;
+        }
+
+        logger.println("No changes");
+        logger.println("Branch [" + this.branchName + "] was created but \"Build on branch created\" is false, not triggering");
+        return false;
+    }
+
     private boolean runPolling() {
         try {
             StreamTaskListener listener = new StreamTaskListener(getLogFile());
@@ -45,26 +72,7 @@ public class BitBucketTriggerRunnable implements Runnable {
                 } else {
                     boolean result = scmTriggerItem.poll(listener).hasChanges();
                     logger.println("Done. Took " + Util.getTimeSpanString(System.currentTimeMillis() - start));
-
-                    if ( this.branchName == null || this.branchName.isEmpty()){
-                        if (result) {
-                            logger.println("Changes found");
-                        } else {
-                            logger.println("No changes");
-                        }
-                    } else {
-                        if ( this.buildOnCreatedBranch){
-                            logger.println("Branch [" + this.branchName + "] was created");
-                            return true;
-                        } else {
-                            logger.println("Branch [" + this.branchName + "] was created but \"Build on branch created\" is false, not triggering");
-                            return false;
-                        }
-
-
-                    }
-
-                    return result;
+                    return shouldTriggerBuild(result, logger);
                 }
             } catch (Error | RuntimeException e) {
                 e.printStackTrace(listener.error("Failed to record SCM polling"));

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitBucketTriggerRunnableTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitBucketTriggerRunnableTest.java
@@ -1,0 +1,97 @@
+package com.cloudbees.jenkins.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Job;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+class BitBucketTriggerRunnableTest {
+
+    @Test
+    void triggersWhenNewBranchPushAlsoContainsChanges() {
+        BitBucketTriggerRunnable runnable =
+                new BitBucketTriggerRunnable("{}", nullJob(), Logger.getAnonymousLogger(), "user", "feature/test", false);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        assertTrue(runnable.shouldTriggerBuild(true, new PrintStream(output)));
+        String log = output.toString(StandardCharsets.UTF_8);
+        assertTrue(log.contains("Changes found"));
+        assertTrue(log.contains("Branch [feature/test] was created"));
+    }
+
+    @Test
+    void doesNotTriggerForBranchCreationWithoutChangesWhenDisabled() {
+        BitBucketTriggerRunnable runnable =
+                new BitBucketTriggerRunnable("{}", nullJob(), Logger.getAnonymousLogger(), "user", "feature/test", false);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        assertFalse(runnable.shouldTriggerBuild(false, new PrintStream(output)));
+        String log = output.toString(StandardCharsets.UTF_8);
+        assertTrue(log.contains("No changes"));
+        assertTrue(log.contains("Build on branch created\" is false, not triggering"));
+    }
+
+    @Test
+    void triggersForBranchCreationWithoutChangesWhenEnabled() {
+        BitBucketTriggerRunnable runnable =
+                new BitBucketTriggerRunnable("{}", nullJob(), Logger.getAnonymousLogger(), "user", "feature/test", true);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        assertTrue(runnable.shouldTriggerBuild(false, new PrintStream(output)));
+        String log = output.toString(StandardCharsets.UTF_8);
+        assertTrue(log.contains("No changes"));
+        assertTrue(log.contains("Branch [feature/test] was created"));
+    }
+
+    @Test
+    void orphanBranchPayloadStillTriggersWhenPollingFindsChangesAndBuildOnCreatedBranchIsFalse() throws IOException {
+        assertPayloadTriggersWithChangesWhenBuildOnCreatedBranchIsFalse("bitbucket_branch_created_orphan_payload.json", "empty_branch1");
+    }
+
+    @Test
+    void branchCreatedWithCommitPayloadStillTriggersWhenPollingFindsChangesAndBuildOnCreatedBranchIsFalse() throws IOException {
+        assertPayloadTriggersWithChangesWhenBuildOnCreatedBranchIsFalse("bitbucket_branch_created_with_commit_payload.json", "not_empty1");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Job<?, ?> nullJob() {
+        return (Job<?, ?>) null;
+    }
+
+    private void assertPayloadTriggersWithChangesWhenBuildOnCreatedBranchIsFalse(String resourceName, String expectedBranchName)
+            throws IOException {
+        JSONObject payload = loadPayload(resourceName);
+        String branchName = payload.getJSONObject("push")
+                .getJSONArray("changes")
+                .getJSONObject(0)
+                .getJSONObject("new")
+                .getString("name");
+
+        BitBucketTriggerRunnable runnable =
+                new BitBucketTriggerRunnable(payload.toString(), nullJob(), Logger.getAnonymousLogger(), "user", branchName, false);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        assertTrue(runnable.shouldTriggerBuild(true, new PrintStream(output)));
+        assertTrue(output.toString(StandardCharsets.UTF_8).contains("Changes found"));
+        assertTrue(output.toString(StandardCharsets.UTF_8).contains("Branch [" + expectedBranchName + "] was created"));
+    }
+
+    private JSONObject loadPayload(String resourceName) throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            return JSONObject.fromObject(IOUtils.toString(input, StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java
@@ -177,4 +177,46 @@ class BitbucketPayloadProcessorTest {
 
         verify(probe).triggerMatchingJobs(eq(user), eq(url), eq("hg"), eq(hgLoad.toString()), isNull(), isNull(), any(byte[].class));
     }
+
+    @Test
+    void processWebhookPayloadBranchCreatedOrphanBranchPassesBranchName() throws IOException {
+        when(request.getHeader("user-agent")).thenReturn("Bitbucket-Webhooks/2.0");
+        when(request.getHeader("x-event-key")).thenReturn("repo:push");
+
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("bitbucket_branch_created_orphan_payload.json")) {
+            JSONObject payload = JSONObject.fromObject(IOUtils.toString(input, StandardCharsets.UTF_8));
+            payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
+
+            verify(probe).triggerMatchingJobs(
+                    eq("example-user"),
+                    eq("https://bitbucket.org/example-user/sample-repo"),
+                    eq("git"),
+                    eq(payload.toString()),
+                    eq("empty_branch1"),
+                    isNull(),
+                    any(byte[].class)
+            );
+        }
+    }
+
+    @Test
+    void processWebhookPayloadBranchCreatedWithCommitPassesBranchName() throws IOException {
+        when(request.getHeader("user-agent")).thenReturn("Bitbucket-Webhooks/2.0");
+        when(request.getHeader("x-event-key")).thenReturn("repo:push");
+
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("bitbucket_branch_created_with_commit_payload.json")) {
+            JSONObject payload = JSONObject.fromObject(IOUtils.toString(input, StandardCharsets.UTF_8));
+            payloadProcessor.processPayload(payload, request, payload.toString().getBytes(StandardCharsets.UTF_8));
+
+            verify(probe).triggerMatchingJobs(
+                    eq("example-user"),
+                    eq("https://bitbucket.org/example-user/sample-repo"),
+                    eq("git"),
+                    eq(payload.toString()),
+                    eq("not_empty1"),
+                    isNull(),
+                    any(byte[].class)
+            );
+        }
+    }
 }

--- a/src/test/resources/bitbucket_branch_created_orphan_payload.json
+++ b/src/test/resources/bitbucket_branch_created_orphan_payload.json
@@ -1,0 +1,37 @@
+{
+  "push": {
+    "changes": [
+      {
+        "old": null,
+        "new": {
+          "name": "empty_branch1",
+          "target": {
+            "type": "commit",
+            "hash": "893ef2b069d431658e3f12f6b4673d1138df2782",
+            "message": "Initial commit on orphan branch\n"
+          },
+          "type": "branch"
+        },
+        "created": true,
+        "commits": [
+          {
+            "type": "commit",
+            "hash": "893ef2b069d431658e3f12f6b4673d1138df2782",
+            "message": "Initial commit on orphan branch\n"
+          }
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/example-user/sample-repo"
+      }
+    },
+    "scm": "git"
+  },
+  "actor": {
+    "nickname": "example-user"
+  }
+}

--- a/src/test/resources/bitbucket_branch_created_with_commit_payload.json
+++ b/src/test/resources/bitbucket_branch_created_with_commit_payload.json
@@ -1,0 +1,37 @@
+{
+  "push": {
+    "changes": [
+      {
+        "old": null,
+        "new": {
+          "name": "not_empty1",
+          "target": {
+            "type": "commit",
+            "hash": "22d6318e7e464ddd1916fa75ff847377839c4b7d",
+            "message": "adding\n"
+          },
+          "type": "branch"
+        },
+        "created": true,
+        "commits": [
+          {
+            "type": "commit",
+            "hash": "22d6318e7e464ddd1916fa75ff847377839c4b7d",
+            "message": "adding\n"
+          }
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/example-user/sample-repo"
+      }
+    },
+    "scm": "git"
+  },
+  "actor": {
+    "nickname": "example-user"
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This fixes [JENKINS-69670](https://issues.jenkins.io/browse/JENKINS-69670), where a Bitbucket Cloud `repo:push` webhook for a newly created branch was incorrectly treated as only a branch-creation event.

Before this change, if the payload had `old: null`, the plugin passed the branch name into the trigger flow and `BitBucketTriggerRunnable` ignored the SCM polling result when `Build on branch created` was unchecked. That caused pushes which both created a branch and introduced a commit to be skipped.

This change preserves the branch-created handling, but still triggers when SCM polling detects changes. The `Build on branch created` option now only suppresses builds when the branch was created and polling reports no changes.

Relevant issue:
- [JENKINS-69670](https://issues.jenkins.io/browse/JENKINS-69670)

Relevant pull requests:
- This pull request: https://github.com/jenkinsci/bitbucket-plugin/pull/161

### Testing done

Automated tests:
- Added regression tests in [BitBucketTriggerRunnableTest.java](/Users/tzach/personal/bitbucket-plugin/src/test/java/com/cloudbees/jenkins/plugins/BitBucketTriggerRunnableTest.java) covering:
  - branch created + polling finds changes + `buildOnCreatedBranch=false` => triggers
  - branch created + polling finds no changes + `buildOnCreatedBranch=false` => does not trigger
  - branch created + polling finds no changes + `buildOnCreatedBranch=true` => triggers
- Added payload-based tests in [BitbucketPayloadProcessorTest.java](/Users/tzach/personal/bitbucket-plugin/src/test/java/com/cloudbees/jenkins/plugins/BitbucketPayloadProcessorTest.java) using Bitbucket Cloud `repo:push` fixtures for:
  - an orphan branch creation payload with a commit
  - a new branch creation payload with a commit
- Added fixture files:
  - [bitbucket_branch_created_orphan_payload.json](/Users/tzach/personal/bitbucket-plugin/src/test/resources/bitbucket_branch_created_orphan_payload.json)
  - [bitbucket_branch_created_with_commit_payload.json](/Users/tzach/personal/bitbucket-plugin/src/test/resources/bitbucket_branch_created_with_commit_payload.json)

Command run:
```bash
mvn -Dtest=BitBucketTriggerRunnableTest,BitbucketPayloadProcessorTest test
```

Result:
- `BUILD SUCCESS`
- `Tests run: 13, Failures: 0, Errors: 0, Skipped: 0`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed