### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bitbucket Plugin for Jenkins
 ============================
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/bitbucket-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/bitbucket-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fbitbucket-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/bitbucket-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/bitbucket.svg)](https://plugins.jenkins.io/bitbucket/)
 [![GitHub release](https://img.shields.io/github/v/release/jenkinsci/bitbucket-plugin?label=changelog)](https://github.com/jenkinsci/bitbucket-plugin/releases/latest/)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/bitbucket.svg?color=blue)](https://plugins.jenkins.io/bitbucket/)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
