### PR TITLE
292-jenkins-cant-work-after-updating-this-plugin - fix - Avoid NoClas…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketJobProbe.java
@@ -34,7 +34,6 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import com.google.common.base.Objects;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
-import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 
 public class BitbucketJobProbe {
 
@@ -289,16 +288,15 @@ public class BitbucketJobProbe {
     }
 
     private boolean match(SCMSource scm, URIish url) {
-        if (scm instanceof GitSCMSource || (isBranchPluginAvailable && scm instanceof BitbucketSCMSource)) {
+        String bitbucketRemote = getBitbucketSCMSourceRemote(scm);
+        if (scm instanceof GitSCMSource || bitbucketRemote != null) {
             String gitRemote;
             if (scm instanceof GitSCMSource) {
                 LOGGER.log(Level.FINEST, "SCMSource is GitSCMSource");
                 gitRemote = ((GitSCMSource) scm).getRemote();
-            } else if (isBranchPluginAvailable) {
+            } else if (bitbucketRemote != null) {
                 LOGGER.log(Level.FINEST, "SCMSource is BitbucketSCMSource");
-                gitRemote = ((BitbucketSCMSource) scm).getServerUrl() + "/" +
-                            ((BitbucketSCMSource) scm).getRepoOwner() + "/" +
-                            ((BitbucketSCMSource) scm).getRepository();
+                gitRemote = bitbucketRemote;
             } else {
                 return false;
             }
@@ -350,6 +348,33 @@ public class BitbucketJobProbe {
             LOGGER.log(Level.SEVERE, "Could not parse repository uri: {0}, {1}", new Object[]{repository, ex});
         }
         return result;
+    }
+
+    private String getBitbucketSCMSourceRemote(SCMSource scm) {
+        if (!isBranchPluginAvailable || scm == null) {
+            return null;
+        }
+        Class<?> clazz = scm.getClass();
+        boolean isBitbucketSCMSource = false;
+        while (clazz != null && clazz != Object.class) {
+            if ("com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource".equals(clazz.getName())) {
+                isBitbucketSCMSource = true;
+                break;
+            }
+            clazz = clazz.getSuperclass();
+        }
+        if (!isBitbucketSCMSource) {
+            return null;
+        }
+        try {
+            String serverUrl = (String) scm.getClass().getMethod("getServerUrl").invoke(scm);
+            String repoOwner = (String) scm.getClass().getMethod("getRepoOwner").invoke(scm);
+            String repository = (String) scm.getClass().getMethod("getRepository").invoke(scm);
+            return serverUrl + "/" + repoOwner + "/" + repository;
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            LOGGER.log(Level.FINE, "Failed to read BitbucketSCMSource properties reflectively", e);
+            return null;
+        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(BitbucketJobProbe.class.getName());

--- a/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtils.java
@@ -1,6 +1,5 @@
 package com.cloudbees.jenkins.plugins;
 
-import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
@@ -10,6 +9,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -20,6 +20,8 @@ final class BitbucketLinkUtils {
 
     static final String REPOSITORY_LINK_NAME = "Browse Repository";
     static final String BRANCH_LINK_NAME = "View Branch";
+    private static final String BITBUCKET_SCM_SOURCE_CLASS =
+            "com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource";
 
     Optional<BitbucketExternalLink> createRepoLink(SCMSource source) {
         return resolve(source)
@@ -43,15 +45,40 @@ final class BitbucketLinkUtils {
         if (source instanceof GitSCMSource) {
             return parseRemote(((GitSCMSource) source).getRemote());
         }
-        if (source instanceof BitbucketSCMSource) {
-            BitbucketSCMSource bitbucketSource = (BitbucketSCMSource) source;
-            return fromCoordinates(
-                    bitbucketSource.getServerUrl(),
-                    bitbucketSource.getRepoOwner(),
-                    bitbucketSource.getRepository()
-            );
+        Optional<BitbucketRemote> bitbucketSourceRemote = resolveBitbucketSCMSource(source);
+        if (bitbucketSourceRemote.isPresent()) {
+            return bitbucketSourceRemote;
         }
         return Optional.empty();
+    }
+
+    private Optional<BitbucketRemote> resolveBitbucketSCMSource(SCMSource source) {
+        if (source == null) {
+            return Optional.empty();
+        }
+        Class<?> clazz = source.getClass();
+        boolean isBitbucketSCMSource = false;
+        while (clazz != null && clazz != Object.class) {
+            if (BITBUCKET_SCM_SOURCE_CLASS.equals(clazz.getName())) {
+                isBitbucketSCMSource = true;
+                break;
+            }
+            clazz = clazz.getSuperclass();
+        }
+        if (!isBitbucketSCMSource) {
+            return Optional.empty();
+        }
+        try {
+            Method getServerUrl = source.getClass().getMethod("getServerUrl");
+            Method getRepoOwner = source.getClass().getMethod("getRepoOwner");
+            Method getRepository = source.getClass().getMethod("getRepository");
+            String serverUrl = (String) getServerUrl.invoke(source);
+            String repoOwner = (String) getRepoOwner.invoke(source);
+            String repository = (String) getRepository.invoke(source);
+            return fromCoordinates(serverUrl, repoOwner, repository);
+        } catch (ReflectiveOperationException | ClassCastException ignored) {
+            return Optional.empty();
+        }
     }
 
     Optional<BitbucketRemote> resolve(SCM scm) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkActionFactoryTest.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.plugins;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import hudson.plugins.mercurial.MercurialSCMSource;
 import jenkins.branch.BranchSource;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead;
@@ -12,6 +13,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @WithJenkins
 class BitbucketLinkActionFactoryTest {
@@ -62,5 +64,16 @@ class BitbucketLinkActionFactoryTest {
         assertEquals(false, BitbucketJobLinkActionFactory.supportsBranchLink(new PullRequestHead("PR-1")));
         assertEquals(false, BitbucketJobLinkActionFactory.supportsBranchLink(new TagHead("v1.0.0")));
         assertEquals(true, BitbucketJobLinkActionFactory.supportsBranchLink(new SCMHead("main") {}));
+    }
+
+    @Test
+    void multibranchProjectsWithAnotherScmSourceDoNotFail(JenkinsRule j) throws Exception {
+        WorkflowMultiBranchProject project = j.jenkins.createProject(WorkflowMultiBranchProject.class, "mbp-mercurial");
+        project.getSourcesList().add(new BranchSource(
+                new MercurialSCMSource("https://example.invalid/repository")));
+
+        BitbucketExternalLink action = project.getAction(BitbucketExternalLink.class);
+
+        assertNull(action);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketLinkUtilsTest.java
@@ -1,10 +1,14 @@
 package com.cloudbees.jenkins.plugins;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BitbucketLinkUtilsTest {
@@ -98,5 +102,34 @@ class BitbucketLinkUtilsTest {
         assertFalse(linkUtils.parseRemote("https://github.com/jenkinsci/bitbucket-plugin.git").isPresent());
         assertFalse(linkUtils.parseRemote("git@github.com:jenkinsci/bitbucket-plugin.git").isPresent());
         assertFalse(linkUtils.parseRemote("git@gitlab.com:group/repo.git").isPresent());
+    }
+
+    @Test
+    void handlesUnknownOrNullSCMSourceSafely() {
+        assertFalse(linkUtils.createRepoLink((jenkins.scm.api.SCMSource) null).isPresent());
+        assertFalse(linkUtils.createBranchLink((jenkins.scm.api.SCMSource) null, "main").isPresent());
+
+        jenkins.scm.api.SCMSource customSource = org.mockito.Mockito.mock(jenkins.scm.api.SCMSource.class);
+
+        assertFalse(linkUtils.createRepoLink(customSource).isPresent());
+        assertFalse(linkUtils.createBranchLink(customSource, "main").isPresent());
+    }
+
+    @Test
+    void optionalBitbucketBranchSourceIsNotHardLinked() throws IOException {
+        assertDoesNotReferenceOptionalBitbucketClass(BitbucketLinkUtils.class);
+        assertDoesNotReferenceOptionalBitbucketClass(BitbucketJobProbe.class);
+    }
+
+    private static void assertDoesNotReferenceOptionalBitbucketClass(Class<?> type) throws IOException {
+        String resourceName = "/" + type.getName().replace('.', '/') + ".class";
+        try (InputStream bytecode = type.getResourceAsStream(resourceName)) {
+            assertNotNull(bytecode, "Missing bytecode resource for " + type.getName());
+            String constantPool = new String(bytecode.readAllBytes(), StandardCharsets.ISO_8859_1);
+            assertFalse(
+                    constantPool.contains("com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource"),
+                    type.getName() + " must not hard-link the optional Bitbucket Branch Source plugin"
+            );
+        }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/BitbucketOptionalDependencyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/BitbucketOptionalDependencyTest.java
@@ -1,0 +1,35 @@
+package com.cloudbees.jenkins.plugins;
+
+import hudson.plugins.mercurial.MercurialSCMSource;
+import jenkins.branch.BranchSource;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BitbucketOptionalDependencyTest {
+
+    @RegisterExtension
+    private static final RealJenkinsExtension REAL_JENKINS = new RealJenkinsExtension()
+            .omitPlugins("cloudbees-bitbucket-branch-source")
+            .withTimeout(120);
+
+    @Test
+    void multibranchActionsWorkWithoutBitbucketBranchSource() throws Throwable {
+        REAL_JENKINS.then(BitbucketOptionalDependencyTest::verifyMultibranchActions);
+    }
+
+    private static void verifyMultibranchActions(JenkinsRule j) throws Exception {
+        assertNull(j.jenkins.getPlugin("cloudbees-bitbucket-branch-source"));
+
+        WorkflowMultiBranchProject project =
+                j.jenkins.createProject(WorkflowMultiBranchProject.class, "mbp-mercurial");
+        project.getSourcesList().add(new BranchSource(
+                new MercurialSCMSource("https://example.invalid/repository")));
+
+        assertNull(project.getAction(BitbucketExternalLink.class));
+    }
+}


### PR DESCRIPTION
 ## Description

    Resolves a `java.lang.NoClassDefFoundError: com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource` that occurs when `cloudbees-bitbucket-branch-source` is not installed on the Jenkins controller.

    ### Background & Root Cause
    `cloudbees-bitbucket-branch-source` is declared as an `<optional>true</optional>` dependency in `pom.xml`. However, `BitbucketLinkUtils` and `BitbucketJobProbe` directly referenced `BitbucketSCMSource` in bytecode. When Jenkins evaluated project actions/folder
  icons (via `BitbucketMultibranchLinkActionFactory`), the JVM attempted to resolve `BitbucketSCMSource`, throwing `NoClassDefFoundError` and crashing Jenkins view rendering for users without the optional plugin installed.

    ### Changes
    - Replaced direct `BitbucketSCMSource` class references and imports with reflective property resolution (`getServerUrl`, `getRepoOwner`, `getRepository`) in `BitbucketLinkUtils` and `BitbucketJobProbe`.
    - Inspected the class hierarchy by name so `BitbucketSCMSource` is only queried dynamically if present.
    - Added tests verifying generic/null `SCMSource` instances and an isolated `RealJenkinsExtension` test with `cloudbees-bitbucket-branch-source` omitted.

    Fixes #292

    ---

    ### Testing done

    - *Isolated Jenkins Integration Test (`BitbucketOptionalDependencyTest`):*
      - Uses `RealJenkinsExtension` configured with `.omitPlugins("cloudbees-bitbucket-branch-source")` to run a real Jenkins instance without the optional plugin installed.
      - Verifies that multibranch projects with non-Bitbucket sources evaluate actions without throwing `NoClassDefFoundError`.
    - *Unit & Integration Tests:*
      - `BitbucketLinkUtilsTest`: Verified link generation with null, third-party, and Bitbucket SCM sources.
      - `BitbucketLinkActionFactoryTest`: Verified action creation for multibranch projects.
      - Full suite passed: `mvn clean test` (36 tests run, 0 failures, 0 errors).

    ---

    ### Submitter checklist
    - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
    - [x] Ensure that the pull request title represents the desired changelog entry
    - [x] Please describe what you did
    - [x] Link to relevant issues in GitHub or Jira
    - [x] Link to relevant pull requests, esp. upstream and downstream changes
    - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

  Sources:
    ▸ github.com
    ▸ github.com